### PR TITLE
Rings - fix inspected value of .take on chords & scales

### DIFF
--- a/app/server/ruby/lib/sonicpi/wrappingarray.rb
+++ b/app/server/ruby/lib/sonicpi/wrappingarray.rb
@@ -27,5 +27,9 @@ module SonicPi
       idx = idx.to_i % size if idx.is_a? Numeric
       self.to_a.slice(idx)
     end
+
+    def take(n)
+      self.to_a.take(n)
+    end
   end
 end


### PR DESCRIPTION
Previously, when calling `.take` on a ring that was in turn based on a
WrappingArray, (ie a Chord or Scale), instead of correctly printing out the ring
*values*, it was printing out the default inspected value of a Chord or Scale.
We now override #take in WrappingArray to make sure that the returned result is
a standard array, meaning in turn that using `puts` on a RingVector will print
out the correct values.

Examples:
Before this change:
```
puts (scale :b2, :major).take(2) # => (ring <SonicPi::Scale :C : )
puts (chord :b2, :maj).take(2) # => (ring <SonicPi::Chord :C : )
```
After this change:
```
puts (scale :b2, :major).take(2) # => (ring 47, 49)
puts (chord :b2, :maj).take(2) # => (ring 47, 51)
```