### PR TITLE
Catch common error

### DIFF
--- a/app/server/ruby/lib/sonicpi/lang/sound.rb
+++ b/app/server/ruby/lib/sonicpi/lang/sound.rb
@@ -1188,6 +1188,7 @@ synth :dsaw, note: :e3 # This is triggered after 0.5s from start"
 
 
       def play(n, *args, &blk)
+        raise "Play expects a note to play, if you did something like 'play sample ...' you should probably remove 'play'" if n.is_a?(SonicPi::Node)
         if n.is_a?(Hash) && args.empty?
           synth nil, n, &blk
         else


### PR DESCRIPTION
A few times* I've noticed people try to run something like:
```
play sample :loop_amen
```
which sort of works, but plays an extra beep at the start of the sample.
Maybe `play` should catch this error and raise a helpful error message?

*e.g. https://in-thread.sonic-pi.net/t/synth-beep-plays-at-the-end-of-samples-for-no-reason/4293
or (not quite the same, but would also catch it): https://in-thread.sonic-pi.net/t/tone-plays-when-sample-plays/4069