### PR TITLE
Core - fix bug in take_last

### DIFF
--- a/app/server/ruby/core.rb
+++ b/app/server/ruby/core.rb
@@ -831,7 +831,7 @@ module SonicPi
 
       def take_last(n=1)
         self if n >= size
-        self[(size-n)..-1]
+        self[(size-n)..size-1]
       end
 
       def butlast


### PR DESCRIPTION
As first raised on in_thread at
https://in-thread.sonic-pi.net/t/a-drum-n-bass-genre-study/1086/14, (thanks to
https://github.com/nlebellier :) ) - previously, the range of values calculated
to grab out of the ring that was passed the `take_last` message was returning
nil for the min and max of the range. This is because take_last was using -1 for
the range max - which means that since the max was less than the min, nil was
returned for these values.
Now, we use size-1 for the range max, so that it will be larger than min, and
the min and max values will not be nil.