### PR TITLE
Fix libaubio file extension in macOS prebuild script

### DIFF
--- a/app/gui/qt/mac-prebuild.sh
+++ b/app/gui/qt/mac-prebuild.sh
@@ -19,7 +19,7 @@ done
 
 if [ "$1" = "--build-aubio" ]; then
   mkdir -p "${SCRIPT_DIR}/../../server/native/lib"
-  cp "${SCRIPT_DIR}/external/build/aubio-prefix/src/aubio-build/libaubio-5.so" "${SCRIPT_DIR}/../../server/native/lib/"
+  cp "${SCRIPT_DIR}/external/build/aubio-prefix/src/aubio-build/libaubio-5.dylib" "${SCRIPT_DIR}/../../server/native/lib/"
 fi
 
 #dont remove ruby-aubio-prerelease, as needed in linux build


### PR DESCRIPTION
Hopefully fixes an error mentioned in #2454, when trying to copy libaubio to the native folder.