### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/app/gui/qt/external/sp_midi/CMakeLists.txt
+++ b/app/gui/qt/external/sp_midi/CMakeLists.txt
@@ -23,8 +23,9 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 #set(oscpack_path ${PROJECT_SOURCE_DIR}/external_libs/oscpack_1_1_0)
 #add_subdirectory(${oscpack_path})
-include_directories( ${PROJECT_SOURCE_DIR}/external_libs/spdlog-0.11.0/include JuceLibraryCode JuceLibraryCode/modules ${PROJECT_SOURCE_DIR}/external_libs/cxxopts ${PROJECT_SOURCE_DIR}/external_libs)
-#include_directories(${PROJECT_SOURCE_DIR}/external_libs/spdlog-0.11.0/include JuceLibraryCode JuceLibraryCode/modules ${PROJECT_SOURCE_DIR}/external_libs/cxxopts)
+#don't include ${PROJECT_SOURCE_DIR}/external_libs globally as it affects linux builds where it is not wanted/ Add instead just for MSCV and APPLE builds
+#include_directories( ${PROJECT_SOURCE_DIR}/external_libs/spdlog-0.11.0/include JuceLibraryCode JuceLibraryCode/modules ${PROJECT_SOURCE_DIR}/external_libs/cxxopts ${PROJECT_SOURCE_DIR}/external_libs)
+include_directories(${PROJECT_SOURCE_DIR}/external_libs/spdlog-0.11.0/include JuceLibraryCode JuceLibraryCode/modules ${PROJECT_SOURCE_DIR}/external_libs/cxxopts)
 
 
 set(sp_midi_sources
@@ -38,11 +39,13 @@ set(sp_midi_sources
 
 if(MSVC)
     list(APPEND sp_midi_sources ${PROJECT_SOURCE_DIR}/external_libs/rtmidi/RtMidi.cpp)
+    include_directories(${PROJECT_SOURCE_DIR}/external_libs)
     add_definitions(-D__WINDOWS_MM__)
 endif(MSVC)
 
 if(APPLE)
     list(APPEND sp_midi_sources ${PROJECT_SOURCE_DIR}/external_libs/rtmidi/RtMidi.cpp)
+    include_directories(${PROJECT_SOURCE_DIR}/external_libs)
     add_definitions(-D__MACOSX_CORE__)
 endif(APPLE)
 
@@ -89,4 +92,3 @@ elseif(UNIX)
     add_definitions(-DLINUX=1 -DNDEBUG=1 -DJUCER_LINUX_MAKE_6D53C8B4=1 -DJUCE_APP_VERSION=1.0.0 -DJUCE_APP_VERSION_HEX=0x10000)
     target_link_libraries(libsp_midi pthread ${ALSA_LIBRARY} dl rtmidi)
 endif(MSVC)
-


### PR DESCRIPTION
Don't include ${PROJECT_SOURCE_DIR}/external_libs globally as it affects Linux builds. Instead add specifically for MSCV and APPLE only