### PR TITLE
Better audio thread performance

### DIFF
--- a/app/gui/qt/visualizer/scope.cpp
+++ b/app/gui/qt/visualizer/scope.cpp
@@ -311,7 +311,7 @@ void AudioProcessingThread::run()
         // We want to try again pretty soon, but we don't want to spin while the UI is doing its thing
         if (!m_processedAudio.m_consumed.load())
         {
-            std::this_thread::yield();
+            std::this_thread::sleep_until(nextTime);
             continue;
         }
 


### PR DESCRIPTION
I recently learned that thread::yield does not yield the rest of the time slice; it can result in a spinning thread (which I've seen), since the thread can be immediately rescheduled.
In this case, if the UI hasn't caught up, we want to wait for the next time slice.
A quick comparison on my local machine gave up to .5% less CPU time when running the same sample with FFT on.

Needs testing to confirm nothing is amiss, but looks good.