### PR TITLE
Properly find lrelease

### DIFF
--- a/app/gui/qt/linux-prebuild.sh
+++ b/app/gui/qt/linux-prebuild.sh
@@ -36,7 +36,7 @@ cp "${SCRIPT_DIR}/utils/ruby_help.tmpl" "${SCRIPT_DIR}/utils/ruby_help.h"
 ruby "${SCRIPT_DIR}/../../server/ruby/bin/qt-doc.rb" -o "${SCRIPT_DIR}/utils/ruby_help.h"
 
 echo "Updating GUI translation files..."
-lrelease "${SCRIPT_DIR}"/lang/*.ts
+PATH=`pkg-config --variable bindir Qt5`:$PATH lrelease "${SCRIPT_DIR}"/lang/*.ts
 
 echo "Compiling erlang files..."
 cd "${SCRIPT_DIR}/../../server/erlang/sonic_pi_server"


### PR DESCRIPTION
On Fedora `lrelease` isn't in the `PATH` because it allows installing different version of Qt. Using pkg-config helps locating it.