### PR TITLE
Fix rounding-induced off-by-one error in line fn

### DIFF
--- a/app/server/ruby/lib/sonicpi/lang/core.rb
+++ b/app/server/ruby/lib/sonicpi/lang/core.rb
@@ -1822,11 +1822,9 @@ end"
         raise ArgumentError, "steps: opt for fn line should be a positive non-zero whole number" unless num_slices > 0
 
         if inclusive
-          step_size = (start - finish).abs.to_f / (num_slices - 1)
-          range(start.to_f, finish.to_f, inclusive: true,  step: step_size)
+          range(0, num_slices).scale((finish - start) / (num_slices - 1)) + start
         else
-          step_size = (start - finish).abs.to_f / num_slices
-          range(start.to_f, finish.to_f, step: step_size)
+          range(0, num_slices).scale((finish - start) / num_slices) + start
         end
       end
       doc name:           :line,


### PR DESCRIPTION
The `line` function sometimes generates rings of the incorrect length.
To fix this, generate a ring of the correct length and then scale it to the right values.

Before:
```ruby
puts line(100, 80, steps: 4, inclusive: true)
# {run: 1, time: 0.0}
#  └─ (ring 100.0, 93.33333333333331, 86.66666666666667)
```
Note that the returned ring only has 3 elements, despite setting `steps: 4`.

After:
```ruby
puts line(100, 80, steps: 4, inclusive: true)
# {run: 2, time: 0.0}
#  └─ (ring 100.0, 93.33333333333333, 86.66666666666667, 80.0)
```