### PR TITLE
Fix - Installation file links are not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Sonic Pi is under active development, and welcomes new contributors:
 * [Change log](CHANGELOG.md)
 * [Community](COMMUNITY.md)
 * [Contributors](CONTRIBUTORS.md)
-* [Installation](INSTALL.md)
+* [Installation](https://github.com/sonic-pi-net/sonic-pi/releases)
 * [License](LICENSE.md)
 * [Testing](TESTING.md)
 * [Translation](TRANSLATION.md)


### PR DESCRIPTION
Redirect installation links to releases page