### PR TITLE
Fix broken Installation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Sonic Pi is under active development, and welcomes new contributors:
 * [Change log](CHANGELOG.md)
 * [Community](COMMUNITY.md)
 * [Contributors](CONTRIBUTORS.md)
-* [Installation](INSTALL.md)
+* [Installation](BUILD-LINUX.md)
 * [License](LICENSE.md)
 * [Testing](TESTING.md)
 * [Translation](TRANSLATION.md)


### PR DESCRIPTION
The current installation link points to a non-existing INSTALL.md 
Assuming that everyone who wants to install it from source is most likely are running Linux.
So pointing it to BUILD-LINUX.md would be an easy fix.