### PR TITLE
Tiny typo in tutorial

### DIFF
--- a/etc/doc/tutorial/02.2-Synth-Params.md
+++ b/etc/doc/tutorial/02.2-Synth-Params.md
@@ -21,7 +21,7 @@ opts (covered in another section).
 
 Opts have two major parts, their name (the name of the control) and
 their value (the value you want to set the control at). For example, you
-might have a opt called `cheese:` and want to set it with a value
+might have an opt called `cheese:` and want to set it with a value
 of `1`.
 
 Opts are passed to calls to `play` by using a comma


### PR DESCRIPTION
Changed "a opt" to "an opt" in tutorial section 2.2