### PR TITLE
Docs - add missing sample

### DIFF
--- a/app/server/ruby/lib/sonicpi/synths/synthinfo.rb
+++ b/app/server/ruby/lib/sonicpi/synths/synthinfo.rb
@@ -7780,7 +7780,8 @@ Note: sliding the `phase:` opt with `phase_slide:` will also cause each echo dur
             :bass_woodsy_c,
             :bass_voxy_c,
             :bass_voxy_hit_c,
-            :bass_dnb_f]},
+            :bass_dnb_f,
+            :bass_trance_c]},
 
         :sn => {
           :desc => "Snare Drums",


### PR DESCRIPTION
The :bass_trance_c sample appears in the list of autocomplete options for
sample, but is not mentioned in the help documentation. This has now been fixed.