### PR TITLE
Repair Windows Debug builds and 32 bit builds

### DIFF
--- a/app/gui/qt/visualizer/server_shm.hpp
+++ b/app/gui/qt/visualizer/server_shm.hpp
@@ -85,7 +85,20 @@ public:
     }
 
 private:
-    string shmem_name;
+#if defined(_WIN64)
+	// Note: this shared memory structure is 32 bytes on the SuperCollider side in 64 bit
+	// at least on a release build which is typically used.
+	// But! A string on windows (or any platform for that matter) does not guarantee that it will consume 32 bytes of memory.
+	// A debug build of windows has this structure bigger than 32 and breaks
+	uint8_t shmem_name[32];
+#else
+#if defined(_WIN32)
+	// ... and on Win32 a debug build has this north of 24, but SC has 24 
+	uint8_t shmem_name[24];
+#else
+	string shmem_name;
+#endif
+#endif
     sh_float_ptr control_busses_; // control busses
     scope_buffer_vector scope_buffers;
 };


### PR DESCRIPTION
Last week this file was changed to remove some code that is required to
align the shared memory with the version of supercollider that we use.

This replaces it; fixing crashes on windows debug builds (and probably
32 bit builds too).