### PR TITLE
Erlang - MIDI - unify on using clock rather than timing_clock to denote MIDI clock ticks

### DIFF
--- a/app/server/erlang/sonic_pi_server/src/pi_server/pi_server_midi_in.erl
+++ b/app/server/erlang/sonic_pi_server/src/pi_server/pi_server_midi_in.erl
@@ -50,7 +50,7 @@ parse(<<1:1, 7:3, 6:4>>) ->
     tune_request;
 
 parse(<<248:8>>) ->
-    timing_clock;
+    clock;
 
 parse(<<250:8>>) ->
     start;
@@ -108,8 +108,8 @@ info(Device, <<Bin/binary>>) ->
         tune_request ->
             {tau, midi, tune_request, [Device], []};
 
-        timing_clock ->
-            {tau, midi, timing_clock, [Device], []};
+        clock ->
+            {tau, midi, clock, [Device], []};
 
         start ->
             {tau, midi, start, [Device], []};

--- a/app/server/erlang/sonic_pi_server/src/pi_server/pi_server_midi_out.erl
+++ b/app/server/erlang/sonic_pi_server/src/pi_server/pi_server_midi_out.erl
@@ -40,7 +40,7 @@ encode({song_select, Value}) ->
     <<1:1, 7:3, 3:4, 0:1, Value:7>>;
 encode(tune_request) ->
     <<1:1, 7:3, 6:4>>;
-encode(timing_clock) ->
+encode(clock) ->
     <<248:8>>;
 encode(start) ->
     <<250:8>>;


### PR DESCRIPTION


Fixes #2631