### PR TITLE
External - spmidi - bring inline with cbef063

### DIFF
--- a/app/external/sp_midi/src/midicommon.cpp
+++ b/app/external/sp_midi/src/midicommon.cpp
@@ -81,15 +81,13 @@ std::vector<MidiPortInfo> MidiCommon::getPortInfo(RtMidi& ports)
 
     for (int i = 0; i < nPorts; i++) {
         auto name = ports.getPortName(i);
+        auto normalizedPortName = name;
+        local_utils::safeOscString(normalizedPortName);
 
-        if (name.rfind("rtmidi_", 0) == 0) {
+        if (normalizedPortName.rfind("rtmidi_", 0) == 0) {
             // The fact that the port name starts with rtmidi tells us that
             // this is a virtual midi port name created by RtMidi - ignore it
         } else {
-
-            auto normalizedPortName = name;
-            local_utils::safeOscString(normalizedPortName);
-
             // Now we need to check for duplicate port names and if they exist,
             // append an integer count to subsequent port names to ensure that
             // they are all unique.  So if there were three devices

--- a/app/external/sp_midi/src/sp_midi.cpp
+++ b/app/external/sp_midi/src/sp_midi.cpp
@@ -58,7 +58,7 @@ static atomic<bool> g_already_initialized { false };
 void prepareMidiSendProcessorOutputs(unique_ptr<MidiSendProcessor>& midiSendProcessor)
 {
     // Open all MIDI devices. This is what Sonic Pi does
-    vector<MidiPortInfo> connectedOutputPortsInfo = MidiIn::getInputPortInfo();
+    vector<MidiPortInfo> connectedOutputPortsInfo = MidiOut::getOutputPortInfo();
     {
         midiSendProcessor->prepareOutputs(connectedOutputPortsInfo);
     }


### PR DESCRIPTION
This address two issues. Firstly an issue with incorrect MIDI out ports and secondly rtmidi virtual ports are now correctly filtered on Linux again.

Fixes #2658