### PR TITLE
add styling for RPi load/save dialog

### DIFF
--- a/app/gui/qt/model/sonicpitheme.cpp
+++ b/app/gui/qt/model/sonicpitheme.cpp
@@ -914,6 +914,10 @@ QString SonicPiTheme::getAppStylesheet() {
 
     appStyling.replace("fixedWidthFont", "\"Hack\"");
 
+    #if defined(Q_OS_LINUX)
+    appStyling = "QWidget\n{\nbackground: paneColor;\n}\n" + appStyling;
+    #endif
+    
     appStyling
         .replace("windowColor", windowColor)
         .replace("windowForegroundColor", windowForegroundColor)


### PR DESCRIPTION
corrects load/save dialog background when running SP on a Raspberry Pi