### PR TITLE
V3.3.1 dev updates for Raspberry Pi

### DIFF
--- a/app/server/ruby/lib/sonicpi/scsynthexternal.rb
+++ b/app/server/ruby/lib/sonicpi/scsynthexternal.rb
@@ -416,7 +416,7 @@ module SonicPi
         puts "Jackd already running. Not starting another server..."
       end
 
-      block_size = raspberry_pi_1? ? 512 : 128
+      block_size = 128
 
       local_scsynth_opts = {
         "-c" => "128",
@@ -429,10 +429,11 @@ module SonicPi
 
       boot_and_wait(scsynth_path, scsynth_opts)
 
-      `jack_connect SuperCollider:in_1 system_capture_1`
-      `jack_connect SuperCollider:in_2 system_capture_2`
       `pactl load-module module-jack-source connect=0 client_name=JACK_to_PulseAudio`
       `pactl load-module module-loopback source=jack_in`
+      `pactl load-module module-jack-sink channels=2 connect=0 client_name=PulseAudio_to_JACK`
+      `jack_connect PulseAudio_to_JACK:front-left SuperCollider:in_1`
+      `jack_connect PulseAudio_to_JACK:front-right SuperCollider:in_2`
       `jack_connect SuperCollider:out_1 JACK_to_PulseAudio:front-left`
       `jack_connect SuperCollider:out_2 JACK_to_PulseAudio:front-right`
       
@@ -440,6 +441,7 @@ module SonicPi
     end
 
     def boot_server_linux
+      #to do -- needs further work
       log_boot_msg
       puts "Booting on Linux"
       #Start Jack if not already running

--- a/app/server/ruby/lib/sonicpi/studio.rb
+++ b/app/server/ruby/lib/sonicpi/studio.rb
@@ -565,7 +565,7 @@ module SonicPi
       # set_mixer! :basic
       # set_mixer! :default
       log_message "Starting mixer"
-      mixer_synth = raspberry_pi_1? ? "sonic-pi-basic_mixer" : "sonic-pi-mixer"
+      mixer_synth = "sonic-pi-mixer"
       @mixer = @server.trigger_synth(:head, @mixer_group, mixer_synth, {"in_bus" => @mixer_bus.to_i}, nil, true)
     end
 

--- a/app/server/ruby/lib/sonicpi/util.rb
+++ b/app/server/ruby/lib/sonicpi/util.rb
@@ -417,28 +417,12 @@ module SonicPi
       File.join(native_path, "sox", __exe_fix("sox"))
     end
 
-    def osmid_o2m_path
-      File.join(native_path, "osmid", __exe_fix("o2m"))
-    end
-
-    def osmid_m2o_path
-      File.join(native_path, "osmid", __exe_fix("m2o"))
-    end
-
     def scsynth_log_path
       log_path + '/scsynth.log'
     end
 
     def erlang_log_path
       log_path + '/erlang.log'
-    end
-
-    def osmid_m2o_log_path
-      log_path + '/osmid_m2o.log'
-    end
-
-    def osmid_o2m_log_path
-      log_path + '/osmid_o2m.log'
     end
 
     def ruby_path

--- a/app/server/ruby/lib/sonicpi/util.rb
+++ b/app/server/ruby/lib/sonicpi/util.rb
@@ -56,7 +56,6 @@ module SonicPi
     @@current_uuid = nil
     @@home_dir = nil
     @@util_lock = Mutex.new
-    @@raspberry_pi_1 = RUBY_PLATFORM.match(/.*arm.*-linux.*/) && File.exist?('/proc/cpuinfo') && !(`cat /proc/cpuinfo | grep BCM2708`).empty?
     @@raspberry_pi_2 = RUBY_PLATFORM.match(/.*arm.*-linux.*/) && ['a01040','a01041','a22042'].include?(`awk '/^Revision/ { print $3}' /proc/cpuinfo`.delete!("\n"))
     @@raspberry_pi_3 = RUBY_PLATFORM.match(/.*arm.*-linux.*/) && ['a02082','a22082','a32082'].include?(`awk '/^Revision/ { print $3}' /proc/cpuinfo`.delete!("\n"))
     @@raspberry_pi_3bplus = RUBY_PLATFORM.match(/.*arm.*-linux.*/) && ['a020d3'].include?(`awk '/^Revision/ { print $3}' /proc/cpuinfo`.delete!("\n"))
@@ -116,10 +115,6 @@ module SonicPi
 
     def raspberry_pi?
       os == :raspberry
-    end
-
-    def raspberry_pi_1?
-      os == :raspberry && @@raspberry_pi_1
     end
 
     def raspberry_pi_2?
@@ -195,17 +190,15 @@ module SonicPi
     end
 
     def num_audio_busses_for_current_os
-      if os == :raspberry && @@raspberry_pi_1
-        64
-      else
         1024
-      end
-
     end
 
     def default_sched_ahead_time
-      if raspberry_pi_1?
-        1
+      if raspberry_pi_2?
+        2
+      elsif  raspberry_pi_3? or raspberry_pi_3bplus? \
+         or raspberry_pi_3_64? or raspberry_pi_3bplus_64?
+        1.5
       else
         0.5
       end
@@ -214,9 +207,7 @@ module SonicPi
     def host_platform_desc
       case os
       when :raspberry
-        if raspberry_pi_1?
-          "Raspberry Pi 1"
-        elsif raspberry_pi_2?
+        if raspberry_pi_2?
           "Raspberry Pi 2B"
         elsif raspberry_pi_3?
           "Raspberry Pi 3B"
@@ -260,11 +251,7 @@ module SonicPi
 
     def default_control_delta
       if raspberry_pi?
-        if raspberry_pi_1?
-          0.02
-        else
           0.013
-        end
       else
         0.005
       end


### PR DESCRIPTION
removes references to Pi1 (wont run on latest OS)
Update default_sched_ahead_times for Pi2 and Pi3
Add pulseaudio hooks for inputs to SuperCollider to RPi boot.