### PR TITLE
Lang - add fn to get current random source

### DIFF
--- a/app/server/ruby/lib/sonicpi/lang/core.rb
+++ b/app/server/ruby/lib/sonicpi/lang/core.rb
@@ -3867,6 +3867,34 @@ puts rand               #=> 0.464202880859375
 puts rand               #=> 0.24249267578125
 "]
 
+      def current_random_source
+        SonicPi::Core::SPRand.get_random_number_distribution
+      end
+      doc name:          :current_random_source,
+          introduced:    Version.new(3,3,2),
+          summary:       "Get current random source",
+          doc:           "Returns the source of the current random number generator (what kind of noise is generating the random numbers).
+
+This can be set via the fns `use_random_source` and `with_random_source`. Each source will provide a different pattern of random numbers.",
+          args:          [],
+          opts:          nil,
+          accepts_block: false,
+          examples:      ["
+  puts current_random_source # Print out the current random source",
+"
+use_random_source :white # Use white noise as the distribution (default)
+puts rand # => 0.75006103515625
+puts rand # => 0.733917236328125
+a = current_random_source # Grab the current random number source (:white)
+use_random_source :perlin # Use perlin noise as the distribution
+puts rand # => 0.58526611328125
+puts rand # => 0.597015380859375
+use_random_source a # Restore the previous random number source (:white)
+                    # The numbers will again be generated from a white noise distribution
+puts rand # => 0.10821533203125
+puts rand # => 0.54010009765625
+"]
+
 
       def current_bpm
         __current_bpm

--- a/app/server/ruby/lib/sonicpi/runtime.rb
+++ b/app/server/ruby/lib/sonicpi/runtime.rb
@@ -1049,7 +1049,9 @@ module SonicPi
           __thread_locals_reset!(new_tls)
           __system_thread_locals_reset!(new_system_tls)
           __set_default_system_thread_locals!
-
+          unless SonicPi::Core::SPRand.get_random_number_distribution
+            SonicPi::Core::SPRand.set_random_number_distribution!(:white)
+          end
           __system_thread_locals.set_local(:sonic_pi_local_thread_group, :job_subthread)
           __system_thread_locals.set_local(:sonic_pi_spider_thread_id_path, new_thread_id_path)
           __system_thread_locals.set_local :sonic_pi_local_spider_users_thread_name, name if name

--- a/app/server/ruby/test/lang/core/test_random.rb
+++ b/app/server/ruby/test/lang/core/test_random.rb
@@ -52,6 +52,13 @@ module SonicPi
       use_random_source :white
     end
 
+    def test_current_random_source
+      use_random_source :perlin
+      assert_equal(:perlin, current_random_source)
+      # return to default
+      use_random_source :white
+    end
+
     def test_rand_reset
       rand_reset
       assert_equal(rand, 0.75006103515625)

--- a/app/server/ruby/test/lang/core/test_random.rb
+++ b/app/server/ruby/test/lang/core/test_random.rb
@@ -39,7 +39,7 @@ module SonicPi
       rand_reset
       assert_equal(rand, 0.546478271484375)
       assert_equal(rand, 0.573150634765625)
-      with_random_source :white do
+      with_random_source :white do
         # matches 3rd value from test_rand
         # index is not reset when changing type
         assert_equal(rand, 0.464202880859375)

--- a/app/server/ruby/test/lang/core/test_threads.rb
+++ b/app/server/ruby/test/lang/core/test_threads.rb
@@ -38,6 +38,14 @@ module SonicPi
 
     end
 
+    def test_in_thread_random_source_initialised
+      @lang.run do
+        t = in_thread do
+          assert_equal :white, current_random_source
+        end
 
+        t.join
+      end
+    end
   end
 end


### PR DESCRIPTION
This brings the random source functions into line with other similar use_/with_*
functions by including a corresponding current_* function to get the current
random number source.

![Screen Shot 2021-02-06 at 4 42 18 pm](https://user-images.githubusercontent.com/10395940/107113726-b7ee4f00-689b-11eb-8455-da5353164f59.png)
