### PR TITLE
GUI - autocomplete use_/with_random_source choices

### DIFF
--- a/app/gui/qt/utils/scintilla_api.cpp
+++ b/app/gui/qt/utils/scintilla_api.cpp
@@ -40,6 +40,8 @@ ScintillaAPI::ScintillaAPI(QsciLexer *lexer)
   keywords[Tuning] << ":just" << ":pythagorean" << ":meantone" << ":equal";
 
   keywords[MidiParam] << "sustain:" << "velocity:" << "vel:" << "velocity_f:" << "vel_f:" << "port:" << "channel:";
+
+  keywords[RandomSource] << ":white" << ":light_pink" << ":pink" << ":dark_pink" << ":perlin";
 }
 
 
@@ -127,7 +129,8 @@ void ScintillaAPI::updateAutoCompletionList(const QStringList &context,
     ctx = Synth;
   } else if (last == "load_example") {
     ctx = Examples;
-
+  } else if (last == "use_random_source" || last == "with_random_source") {
+    ctx = RandomSource;
   // autocomplete the second arg of scale/chord
   } else if (lastButOne == "scale") {
     ctx = Scale;

--- a/app/gui/qt/utils/scintilla_api.h
+++ b/app/gui/qt/utils/scintilla_api.h
@@ -17,7 +17,7 @@
 class ScintillaAPI : public QsciAbstractAPIs
 {
  public:
-  enum { Func, FX, Synth, Sample, Chord, Scale, MCBlock, PlayParam, SampleParam, Tuning, Examples, MidiParam, MidiOuts, CuePath, NContext};
+  enum { Func, FX, Synth, Sample, Chord, Scale, MCBlock, PlayParam, SampleParam, Tuning, Examples, MidiParam, MidiOuts, CuePath, RandomSource, NContext};
 
   ScintillaAPI(QsciLexer *lexer);
 


### PR DESCRIPTION
This pops up autocompletion options for the types of noise that people can pick
when setting the random number source through use_random_source or with_random_source.
![Screen Shot 2021-02-06 at 9 27 05 pm](https://user-images.githubusercontent.com/10395940/107119388-2e05ac80-68c2-11eb-976a-9e95de3fc534.png)

![Screen Shot 2021-02-06 at 9 27 42 pm](https://user-images.githubusercontent.com/10395940/107119390-352cba80-68c2-11eb-96c2-4a4dd3aa8988.png)
