### PR TITLE
Fix doc examples

### DIFF
--- a/app/server/ruby/lib/sonicpi/lang/core.rb
+++ b/app/server/ruby/lib/sonicpi/lang/core.rb
@@ -3132,14 +3132,16 @@ end
 
 Does not consume a random value from the stream. Therefore, multiple sequential calls to `rand_look` will all return the same value.",
           examples:       ["
-  print rand_look(0.5) #=> will print a number like 0.375030517578125 to the output pane",
+print rand_look(0.5) # will print a number like 0.375030517578125 to the output pane",
 
         "
-  print rand_look(0.5) #=> will print a number like 0.375030517578125 to the output pane
-  print rand_look(0.5) #=> will print the same number again
-  print rand_look(0.5) #=> will print the same number again
-  print rand(0.5) #=> will print a different random number
-  print rand_look(0.5) #=> will print the same number as the previous line again."
+print rand_look(0.5) # will print a number like 0.375030517578125 to the output pane
+print rand_look(0.5) # will print the same number again
+print rand_look(0.5) # will print the same number again
+print rand(0.5) # will still print the same number again
+                # (this is the number rand_look was 'looking ahead' at)
+                # the number is now consumed
+print rand_look(0.5) # will print a new number like 0.3669586181640625 to the output pane"
       ]
 
 
@@ -3160,14 +3162,16 @@ Does not consume a random value from the stream. Therefore, multiple sequential 
 
 Does not consume a random value from the stream. Therefore, multiple sequential calls to `rand_i_look` will all return the same value.",
           examples:       ["
-print rand_i_look(5) #=> will print either 0, 1, 2, 3, or 4 to the output pane",
+print rand_i_look(5) # will print either 0, 1, 2, 3, or 4 to the output pane",
 
         "
-print rand_i_look(5) #=> will print either 0, 1, 2, 3, or 4 to the output pane
-print rand_i_look(5) #=> will print the same number again
-print rand_i_look(5) #=> will print the same number again
-print rand_i(5) #=> will print either 0, 1, 2, 3, or 4 to the output pane
-print rand_i_look(5) #=> will print the same number as the previous statement"
+print rand_i_look(5) # will print either 0, 1, 2, 3, or 4 to the output pane
+print rand_i_look(5) # will print the same number again
+print rand_i_look(5) # will print the same number again
+print rand_i(5) # will still print the same number again
+                # (this is the number rand_i_look was 'looking ahead' at)
+                # the number is now consumed
+print rand_i_look(5) # will print either 0, 1, 2, 3, or 4 to the output pane"
       ]
 
 

--- a/app/server/ruby/lib/sonicpi/lang/core.rb
+++ b/app/server/ruby/lib/sonicpi/lang/core.rb
@@ -3315,9 +3315,9 @@ print rand_i_look(5) #=> will print the same number as the previous statement"
   ## Basic usage
 
   use_random_seed 1 # reset random seed to 1
-  puts rand # => 0.417022004702574
+  puts rand # => 0.733917236328125
   use_random_seed 1 # reset random seed back to 1
-  puts rand  #=> 0.417022004702574
+  puts rand  #=> 0.733917236328125
   ",
   "
   ## Generating melodies
@@ -3372,15 +3372,15 @@ print rand_i_look(5) #=> will print the same number as the previous statement"
           requires_block: true,
           examples:      ["
   use_random_seed 1 # reset random seed to 1
-  puts rand # => 0.417022004702574
-  puts rand  #=> 0.7203244934421581
+  puts rand # => 0.733917236328125
+  puts rand  #=> 0.464202880859375
   use_random_seed 1 # reset it back to 1
-  puts rand # => 0.417022004702574
+  puts rand # => 0.733917236328125
   with_random_seed 1 do # reset seed back to 1 just for this block
-    puts rand # => 0.417022004702574
-    puts rand #=> 0.7203244934421581
+    puts rand # => 0.733917236328125
+    puts rand #=> 0.464202880859375
   end
-  puts rand # => 0.7203244934421581
+  puts rand # => 0.464202880859375
             # notice how the original generator is restored",
   "
   ## Generating melodies


### PR DESCRIPTION
This PR includes updates to several documentation examples that have been describing their output incorrectly for a little while.

Fixes #2690 
Fixes #2693 

New `use_random_seed` examples:
![Screen Shot 2021-02-07 at 4 38 21 pm](https://user-images.githubusercontent.com/10395940/107141315-eaaf4a80-6962-11eb-8e6b-c1bf77b802e4.png)

New `with_random_seed` examples:
![Screen Shot 2021-02-07 at 4 39 50 pm](https://user-images.githubusercontent.com/10395940/107141350-1e8a7000-6963-11eb-8d3b-c7e5f517b087.png)

New `rand_i_look` examples:
![Screen Shot 2021-02-07 at 4 36 03 pm](https://user-images.githubusercontent.com/10395940/107141276-a4f28200-6962-11eb-839a-36f9999b4d63.png)

New `rand_look` examples:
![Screen Shot 2021-02-07 at 4 37 00 pm](https://user-images.githubusercontent.com/10395940/107141287-b9367f00-6962-11eb-9f4d-d804aded9a48.png)
