### PR TITLE
Simple fix for snippets

### DIFF
--- a/app/api/src/osc/osc_handler.cpp
+++ b/app/api/src/osc/osc_handler.cpp
@@ -182,7 +182,7 @@ void OscHandler::oscMessage(std::vector<char> buffer)
         else if (msg->match("/buffer/replace-lines"))
         {
             BufferInfo info;
-            info.type = BufferType::Replace;
+            info.type = BufferType::ReplaceLines;
             if (msg->arg().popStr(info.id).popStr(info.content).popInt32(info.startLine).popInt32(info.finishLine).popInt32(info.pointLine).popInt32(info.pointIndex).isOkNoMoreArgs())
             {
                 LOG(DBG, "/buffer/replace-lines: " << info.index);


### PR DESCRIPTION
The new API accidentaly set the wrong message type for the
/buffer/replace-lines message.  Fix for BufferType::ReplaceLines

Tested with ll<TAB> to insert a live loop.