### PR TITLE
Docs - fix use/with_real_time examples

### DIFF
--- a/app/server/ruby/lib/sonicpi/lang/core.rb
+++ b/app/server/ruby/lib/sonicpi/lang/core.rb
@@ -4072,7 +4072,7 @@ See `use_sched_ahead_time` for a version of this function which allows you to se
           opts:          nil,
           modifies_env: true,
           accepts_block: false,
-          examples:      ["use_real_time 1 # Code will now run approximately 1 second ahead of audio."]
+          examples:      ["use_real_time # Code will now produce sound without a scheduling delay."]
 
 
       def with_real_time(&blk)
@@ -4101,8 +4101,12 @@ See `with_sched_ahead_time` for a version of this function which allows you to s
           opts:          nil,
           modifies_env: true,
           accepts_block: false,
-          examples:      ["use_real_time 1 # Code will now run approximately 1 second ahead of audio."]
+          examples:      ["
+with_real_time do
+  play 70  # Sound will happen without a scheduling delay.
+end
 
+play 70  # Sound will happen with the default latency (0.5s)."]
 
       def with_sched_ahead_time t, &blk
         raise ArgumentError, "with_sched_ahead_time must be called with a do/end block. Perhaps you meant use_sched_ahead_time" unless blk


### PR DESCRIPTION
Previously, the examples for the use_real_time and with_real_time functions were
both misleading - they demonstrated incorrect usage and described incorrect
behaviour.
They have now been updated.

Before the change:
<img width="1209" alt="use_real_time before" src="https://user-images.githubusercontent.com/10395940/108616211-58b93e80-7446-11eb-899b-fe620441e895.png">

<img width="1210" alt="with_real_time before" src="https://user-images.githubusercontent.com/10395940/108616212-5d7df280-7446-11eb-90dc-12c42b63fb2e.png">

After the change:
<img width="1209" alt="use_real_time after" src="https://user-images.githubusercontent.com/10395940/108616166-f2342080-7445-11eb-928d-cf2e9c740234.png">

<img width="1207" alt="with_real_time after" src="https://user-images.githubusercontent.com/10395940/108616170-f82a0180-7445-11eb-9f6b-a1b50bbebf7f.png">
