### PR TITLE
Fix lookup of samples

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -229,7 +229,7 @@ MainWindow::MainWindow(QApplication& app, bool i18n, QSplashScreen* splash)
     initDocsWindow();
 
     //setup autocompletion
-    autocomplete->loadSamples(sample_path);
+    autocomplete->loadSamples(QString::fromStdString(m_spAPI->GetPath(SonicPiPath::SamplePath)));
 
     QThreadPool::globalInstance()->setMaxThreadCount(3);
 
@@ -456,8 +456,8 @@ void MainWindow::checkForStudioMode()
     std::cout << "[GUI] - Fetching Studio hashes" << std::endl;
     QProcess* fetchStudioHashes = new QProcess();
     QStringList fetch_studio_hashes_send_args;
-    fetch_studio_hashes_send_args << fetch_url_path << "http://sonic-pi.net/static/info/studio-hashes.txt";
-    fetchStudioHashes->start(ruby_path, fetch_studio_hashes_send_args);
+    fetch_studio_hashes_send_args << QString::fromStdString(m_spAPI->GetPath(SonicPiPath::FetchUrlPath)) << "http://sonic-pi.net/static/info/studio-hashes.txt";
+    fetchStudioHashes->start(QString::fromStdString(m_spAPI->GetPath(SonicPiPath::RubyPath)), fetch_studio_hashes_send_args);
     fetchStudioHashes->waitForFinished();
     QTextStream stream(fetchStudioHashes->readAllStandardOutput().trimmed());
     QString line = stream.readLine();

--- a/app/gui/qt/mainwindow.h
+++ b/app/gui/qt/mainwindow.h
@@ -430,7 +430,11 @@ signals:
         std::ofstream stdlog;
 
         ScintillaAPI *autocomplete;
-        QString fetch_url_path, sample_path, log_path, sp_user_path, sp_user_tmp_path, ruby_server_path, ruby_path, server_error_log_path, server_output_log_path, gui_log_path, scsynth_log_path, init_script_path, exit_script_path, tmp_file_store, process_log_path, port_discovery_path, qt_app_theme_path, qt_browser_dark_css, qt_browser_light_css, qt_browser_hc_css;
+#ifdef QT_OLD_API
+        QString fetch_url_path, sample_path, log_path, sp_user_path, sp_user_tmp_path, ruby_server_path, ruby_path, server_error_log_path, server_output_log_path, gui_log_path, scsynth_log_path, init_script_path, exit_script_path, tmp_file_store, process_log_path, port_discovery_path;
+#endif
+        QString qt_browser_dark_css, qt_browser_light_css, qt_browser_hc_css, qt_app_theme_path;
+
         QString defaultTextBrowserStyle;
 
         QString version;


### PR DESCRIPTION
The API has a new GetPath() call for finding out where all the file
folders are; there was a bug where the mainwindow was not using it to
get the paths.  To prevent this, I've also disabled the old cached path
strings in the class.