### PR TITLE
Core - don't error when indexing empty rings

### DIFF
--- a/app/server/ruby/core.rb
+++ b/app/server/ruby/core.rb
@@ -904,8 +904,9 @@ module SonicPi
 
     class RingVector < SPVector
       def map_index(idx)
-        idx = idx % size
-        return idx
+        return idx unless size.positive?
+
+        idx % size
       end
 
       def ___sp_vector_name

--- a/app/server/ruby/test/test_ring.rb
+++ b/app/server/ruby/test/test_ring.rb
@@ -202,5 +202,9 @@ module SonicPi
       assert_equal(3, r.tick)
       assert_equal(3, r.tick)
     end
+
+    def test_index_empty_ring
+      assert_nil(ring()[0])
+    end
   end
 end


### PR DESCRIPTION
Previously, when trying to index into an empty ring, a divide by zero error was
occurring. This has now been fixed.