### PR TITLE
Sample Onsets - include final sample slice in onset_slices

### DIFF
--- a/app/server/ruby/lib/sonicpi/lang/sound.rb
+++ b/app/server/ruby/lib/sonicpi/lang/sound.rb
@@ -3685,7 +3685,7 @@ Also, if you wish your synth to work with Sonic Pi's automatic stereo sound infr
           elsif onset_idx.is_a? Proc
             onset = onset_idx.call(onsets)
             onset = onset[0] if is_list_like?(onset)
-            raise "Result of onset: proc should be a Map such as {:start => 0, :finish => 0.125}. Got: #{res.inspect}" unless onset.respond_to?(:has_key?) && onset[:start].is_a?(Numeric) && onset[:finish].is_a?(Numeric)
+            raise "Result of onset: proc should be a Map such as {:start => 0, :finish => 0.125}. Got: #{onset.inspect}" unless onset.respond_to?(:has_key?) && onset[:start].is_a?(Numeric) && onset[:finish].is_a?(Numeric)
           else
             raise "Unknown sample onset: value. Expected a number or a proc. Got #{onset_idx.inspect}"
           end

--- a/app/server/ruby/lib/sonicpi/samplebuffer.rb
+++ b/app/server/ruby/lib/sonicpi/samplebuffer.rb
@@ -131,12 +131,14 @@ module SonicPi
 
     def onset_slices
       return @aubio_slices if @aubio_slices
-      ons = onsets
+      ons_bounds = onsets
       @aubio_sem.synchronize do
         return @aubio_slices if @aubio_slices
         res = []
-        ons[0...-1].each_with_index do |onset, idx|
-          res << {:start => onset, :finish => ons[idx + 1], index: idx}
+        ons_bounds << 0 if ons_bounds.empty?
+        ons_bounds << 1 if ons_bounds[-1] != 1
+        ons_bounds.each_cons(2).each_with_index do |(start, finish), idx|
+          res << { start: start, finish: finish, index: idx }
         end
         @aubio_slices = res.ring
       end

--- a/app/server/ruby/test/test_sample_buffer.rb
+++ b/app/server/ruby/test/test_sample_buffer.rb
@@ -1,0 +1,48 @@
+#--
+# This file is part of Sonic Pi: http://sonic-pi.net
+# Full project source: https://github.com/samaaron/sonic-pi
+# License: https://github.com/samaaron/sonic-pi/blob/main/LICENSE.md
+#
+# Copyright 2013, 2014, 2015, 2016 by Sam Aaron (http://sam.aaron.name).
+# All rights reserved.
+#
+# Permission is granted for use, copying, modification, and
+# distribution of modified versions of this work as long as this
+# notice is included.
+#++
+
+require_relative './setup_test'
+require_relative '../lib/sonicpi/samplebuffer'
+require 'mocha/setup'
+
+module SonicPi
+  class SampleBufferTester < Minitest::Test
+    def setup
+      @mock_buffer = SampleBuffer.new(nil, '/foo.wav')
+    end
+
+    def test_onset_slices_with_no_onsets
+      @mock_buffer.stubs(:onsets).returns([])
+      expected_slices = [{ start: 0, finish: 1, index: 0 }].ring
+
+      assert_equal(@mock_buffer.onset_slices, expected_slices)
+    end
+
+    def test_onset_slices_with_single_onset
+      @mock_buffer.stubs(:onsets).returns([0])
+      expected_slices = [{ start: 0, finish: 1, index: 0 }].ring
+
+      assert_equal(@mock_buffer.onset_slices, expected_slices)
+    end
+
+    def test_onset_slices_with_multiple_onsets
+      @mock_buffer.stubs(:onsets).returns([0, 0.5])
+      expected_slices = [
+        { start: 0, finish: 0.5, index: 0 },
+        { start: 0.5, finish: 1, index: 1 }
+      ].ring
+
+      assert_equal(@mock_buffer.onset_slices, expected_slices)
+    end
+  end
+end


### PR DESCRIPTION
Previously, when generating the list of sample onset slices, all but the last
slice were being included in the list. This has now been fixed.
The fix also revealed a further problem: the error raised for invalid onset
procs referred to a non-existent variable and therefore itself caused an error.
This also has been fixed.

Possible TODO: handle float precision for onsets that are detected at the very
end of the sample?