### PR TITLE
Fix for osc port display in the UI

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -137,6 +137,7 @@ MainWindow::MainWindow(QApplication& app, bool i18n, QSplashScreen* splash)
     bool startupOK = false;
 
     m_spAPI->Init(rootPath().toStdString());
+    guiID = QString::fromStdString(m_spAPI->GetGuid());
 
     std::cout << "[GUI] - hiding main window" << std::endl;
     hide();
@@ -170,9 +171,6 @@ MainWindow::MainWindow(QApplication& app, bool i18n, QSplashScreen* splash)
     QThreadPool::globalInstance()->setMaxThreadCount(3);
 
     startupOK = m_spAPI->WaitForServer();
-    guiID = QString::fromStdString(m_spAPI->GetGuid());
-    server_osc_cues_port = m_spAPI->GetPort(SonicPiPortId::server_osc_cues);
-    scsynth_port = m_spAPI->GetPort(SonicPiPortId::scsynth);
 
     if (startupOK)
     {
@@ -350,7 +348,7 @@ void MainWindow::setupWindowStructure()
     prefsWidget->setAllowedAreas(Qt::RightDockWidgetArea);
     prefsWidget->setFeatures(QDockWidget::DockWidgetClosable);
 
-    settingsWidget = new SettingsWidget(server_osc_cues_port, piSettings, this);
+    settingsWidget = new SettingsWidget(m_spAPI->GetPort(SonicPiPortId::server_osc_cues), piSettings, this);
     connect(settingsWidget, SIGNAL(volumeChanged(int)), this, SLOT(changeSystemPreAmp(int)));
     connect(settingsWidget, SIGNAL(mixerSettingsChanged()), this, SLOT(mixerSettingsChanged()));
     connect(settingsWidget, SIGNAL(midiSettingsChanged()), this, SLOT(toggleMidi()));
@@ -2783,7 +2781,7 @@ void MainWindow::createToolBar()
     }
 
     QMenu* incomingOSCPortMenu = ioMenu->addMenu(tr("Incoming OSC Port"));
-    incomingOSCPortMenu->addAction(QString::number(server_osc_cues_port));
+    incomingOSCPortMenu->addAction(QString::number(m_spAPI->GetPort(SonicPiPortId::server_osc_cues)));
 
     viewMenu = menuBar()->addMenu(tr("View"));
 

--- a/app/gui/qt/mainwindow.h
+++ b/app/gui/qt/mainwindow.h
@@ -333,9 +333,6 @@ signals:
         QSettings *gui_settings;
         SonicPiSettings *piSettings;
 
-        int server_osc_cues_port;
-        int scsynth_port;
-
         bool focusMode;
         QCheckBox *startup_error_reported;
         bool is_recording;


### PR DESCRIPTION
Bug #2757

The osc port was cached locally in mainwindow from the old API; the
better way to do this is to just ask the API for it.

Since the old API code seems to have been removed, there is more
cleanup that can be done.