### PR TITLE
Accessibility enhancement and Select all fix

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -251,6 +251,7 @@ MainWindow::MainWindow(QApplication &app, bool i18n, QSplashScreen* splash)
         emit settingsChanged();
         splashClose();
         showWindow();
+        focusEditor();
         app.processEvents();
         std::cout << "[GUI] - boot sequence completed." << std::endl;
 

--- a/app/gui/qt/widgets/sonicpiscintilla.cpp
+++ b/app/gui/qt/widgets/sonicpiscintilla.cpp
@@ -109,7 +109,7 @@ SonicPiScintilla::SonicPiScintilla(SonicPiLexer *lexer, SonicPiTheme *theme, QSt
   addKeyBinding(settings, QsciCommand::Redo, Qt::Key_Z | Qt::SHIFT | SPi_META);
   addOtherKeyBinding(settings, QsciCommand::Redo, Qt::Key_Z | Qt::SHIFT | SPi_CTRL);
   addKeyBinding(settings, QsciCommand::SelectAll, Qt::Key_A | SPi_META);
-
+                                                                                   addOtherKeyBinding(settings, QsciCommand::SelectAll, Qt::Key_A | SPi_CTRL);
   // delete word left and right
   addKeyBinding(settings, QsciCommand::DeleteWordLeft, Qt::Key_Backslash | SPi_META);
   addKeyBinding(settings, QsciCommand::DeleteWordLeft, Qt::Key_Backspace | SPi_META);


### PR DESCRIPTION
Currently when sonic-pi runs up nothing is in focus that is useful.  This pull request sets the current edit control to focus.  This way a screen rader knows what to read.  It changes nothing for a sighted user but makes sonic-pi a lot more easy to use for a blind user.

The second commit just fixes select all in windows.  Currently it does not work.  These are very short and easy to review fixes.