### PR TITLE
using Process.detach instead of Process.waitpid

### DIFF
--- a/app/server/ruby/lib/sonicpi/scsynthexternal.rb
+++ b/app/server/ruby/lib/sonicpi/scsynthexternal.rb
@@ -459,10 +459,10 @@ module SonicPi
 
       boot_and_wait(scsynth_path, scsynth_opts)
 
-      `jack_connect SuperCollider:out_1 system:playback_1`
-      `jack_connect SuperCollider:out_2 system:playback_2`
-      `jack_connect SuperCollider:in_1 system:capture_1`
-      `jack_connect SuperCollider:in_2 system:capture_2`
+      #`jack_connect SuperCollider:out_1 system:playback_1`
+      #`jack_connect SuperCollider:out_2 system:playback_2`
+      #`jack_connect SuperCollider:in_1 system:capture_1`
+      #`jack_connect SuperCollider:in_2 system:capture_2`
     end
   end
 end

--- a/app/server/ruby/lib/sonicpi/scsynthexternal.rb
+++ b/app/server/ruby/lib/sonicpi/scsynthexternal.rb
@@ -459,10 +459,10 @@ module SonicPi
 
       boot_and_wait(scsynth_path, scsynth_opts)
 
-      #`jack_connect SuperCollider:out_1 system:playback_1`
-      #`jack_connect SuperCollider:out_2 system:playback_2`
-      #`jack_connect SuperCollider:in_1 system:capture_1`
-      #`jack_connect SuperCollider:in_2 system:capture_2`
+      `jack_connect SuperCollider:out_1 system:playback_1`
+      `jack_connect SuperCollider:out_2 system:playback_2`
+      `jack_connect SuperCollider:in_1 system:capture_1`
+      `jack_connect SuperCollider:in_2 system:capture_2`
     end
   end
 end

--- a/app/server/ruby/lib/sonicpi/util.rb
+++ b/app/server/ruby/lib/sonicpi/util.rb
@@ -181,7 +181,7 @@ module SonicPi
      def raspberry_pi_400_64?
       os == :raspberry && @@raspberry_pi_400_64
     end
-    
+
    def unify_tilde_dir(path)
       if os == :windows
         path
@@ -697,7 +697,7 @@ module SonicPi
 
     def register_process(pid)
       pid = spawn "'#{ruby_path}' '#{File.join(server_bin_path, 'task-register.rb')}' #{pid}"
-      Process.waitpid(pid, Process::WNOHANG)
+      Process.detach pid
     end
 
     def kill_and_deregister_process(pid)


### PR DESCRIPTION
In this instance Process.waitpid creates a zombie process. Using Process.detach does not.