### PR TITLE
Daemon - use jack_wait to detect JACK

### DIFF
--- a/app/server/ruby/bin/daemon.rb
+++ b/app/server/ruby/bin/daemon.rb
@@ -614,7 +614,7 @@ module SonicPi
         case Util.os
         when :linux, :raspberry
           #Start Jack if not already running
-          if `ps cax | grep jackd`.split(" ").first.nil?
+          if `jack_wait -c`.include? 'not running'
             #Jack not running - start a new instance
             Util.log "Jackd not running on system. Starting..."
             @jack_booter = JackBooter.new


### PR DESCRIPTION
Currently on Linux, Sonic Pi is manually checking for "jackd" in the running processes (via `ps cax`), which can be problematic for non-"jackd" servers or for compatible sound servers like [Pipewire](https://pipewire.org/).

When I start Sonic Pi with Pipewire, the logs indicate that it tries to start a new JACK daemon (via running jackd) which fails due to the JACK-compatiable Pipewire daemon already running. This does not seem to be detected as fatal with the server startup code in 3.3.1 or current dev branch and Sonic Pi/SuperCollider seem to be fully compatible with Pipewire otherwise.

To fix the issue, this PR uses the `jack_wait` tool provided in JACK1 and JACK2 installations. The `jack_wait` tool is designed to perform functions like checking if the JACK server is running or for waiting on it to start or quit (see the [manual page](http://manpages.ubuntu.com/manpages/cosmic/man1/jack_wait.1.html)).

Let me know if you need more info or logs demonstrating the issue/fix!