### PR TITLE
GUI - fix building with Qt5 before 5.14

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -2916,7 +2916,11 @@ void MainWindow::createToolBar()
     QStringList available_languages = sonicPii18n->getAvailableLanguages();
 
     langActionGroup = new QActionGroup(this);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
     langActionGroup->setExclusionPolicy(QActionGroup::ExclusionPolicy::Exclusive);
+#else
+    langActionGroup->setExclusive(true);
+#endif
 
     QSignalMapper *signalMapper = new QSignalMapper(this);
 


### PR DESCRIPTION
Ubuntu 20.04 (the current LTS release) only has Qt 5.12 in its repos, but the `QActionGroup::setExclusionPolicy` stuff wasn't added until Qt 5.14. This PR fixes building on Qt 5.12 by using the older `QActionGroup::setExclusive` method when attempting to build it with older Qt versions.

See https://in-thread.sonic-pi.net/t/dev-branch-on-ubuntu-lts-20-04-02/5917 (since I did not personally test this on Ubuntu LTS/Qt 5.12, but nlb on in_thread did)

Qt 5.14 documentation: https://doc.qt.io/qt-5.14/qactiongroup.html#exclusionPolicy-prop
Qt 5.12 documentation: https://doc.qt.io/qt-5.12/qactiongroup.html#exclusive-prop