### PR TITLE
Build - fix CMake LIBDIR stuff for vendored dependencies and link API against librt on Linux

### DIFF
--- a/app/api/CMakeLists.txt
+++ b/app/api/CMakeLists.txt
@@ -84,6 +84,7 @@ find_package(crossguid CONFIG REQUIRED)
 target_link_libraries(${PROJECT_NAME}
     PUBLIC
         stdc++fs
+        rt
     PRIVATE
         crossguid
     )

--- a/app/external/CMakeLists.txt
+++ b/app/external/CMakeLists.txt
@@ -8,7 +8,7 @@ project(AubioBuilder
     VERSION 1.0.0
     )
 
-
+  include(GNUInstallDirs)
   include(ExternalProject)
 
   set(CMAKE_OSX_DEPLOYMENT_TARGET '10.14')
@@ -108,15 +108,15 @@ ExternalProject_Add(libsndfile
         -DCMAKE_POSITION_INDEPENDENT_CODE=ON
         -DFLAC_ROOT=${CMAKE_BINARY_DIR}/flac-package
         -DPC_OGG_INCLUDE_DIRS=${CMAKE_BINARY_DIR}/ogg-package/include
-        -DPC_OGG_LIBRARY_DIRS=${CMAKE_BINARY_DIR}/ogg-package/lib
+        -DPC_OGG_LIBRARY_DIRS=${CMAKE_BINARY_DIR}/ogg-package/${CMAKE_INSTALL_LIBDIR}
         -DPC_FLAC_INCLUDE_DIRS=${CMAKE_BINARY_DIR}/flac-package/include
-        -DPC_FLAC_LIBRARY_DIRS=${CMAKE_BINARY_DIR}/flac-package/lib
+        -DPC_FLAC_LIBRARY_DIRS=${CMAKE_BINARY_DIR}/flac-package/${CMAKE_INSTALL_LIBDIR}
         -DPC_VORBIS_INCLUDE_DIRS=${CMAKE_BINARY_DIR}/vorbis-package/include
-        -DPC_VORBIS_LIBRARY_DIRS=${CMAKE_BINARY_DIR}/vorbis-package/lib
+        -DPC_VORBIS_LIBRARY_DIRS=${CMAKE_BINARY_DIR}/vorbis-package/${CMAKE_INSTALL_LIBDIR}
         -DPC_VORBISENC_INCLUDE_DIRS=${CMAKE_BINARY_DIR}/vorbis-package/include
-        -DPC_VORBISENC_LIBRARY_DIRS=${CMAKE_BINARY_DIR}/vorbis-package/lib
+        -DPC_VORBISENC_LIBRARY_DIRS=${CMAKE_BINARY_DIR}/vorbis-package/${CMAKE_INSTALL_LIBDIR}
         -DPC_OPUS_INCLUDE_DIRS=${CMAKE_BINARY_DIR}/opus-package/include
-        -DPC_OPUS_LIBRARY_DIRS=${CMAKE_BINARY_DIR}/opus-package/lib
+        -DPC_OPUS_LIBRARY_DIRS=${CMAKE_BINARY_DIR}/opus-package/${CMAKE_INSTALL_LIBDIR}
         -DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}
 
         INSTALL_DIR ${CMAKE_BINARY_DIR}/libsndfile-package
@@ -130,11 +130,11 @@ ExternalProject_Add(aubio
 
     CMAKE_ARGS
         -DLIBSNDFILE_INCLUDE_DIR=${CMAKE_BINARY_DIR}/libsndfile-package/include
-        -DLIBSNDFILE_LIBRARY_DIR=${CMAKE_BINARY_DIR}/libsndfile-package/lib
-        -DLIBOGG_LIBRARY_DIR=${CMAKE_BINARY_DIR}/ogg-package/lib
-        -DLIBVORBIS_LIBRARY_DIR=${CMAKE_BINARY_DIR}/vorbis-package/lib
-        -DLIBOPUS_LIBRARY_DIR=${CMAKE_BINARY_DIR}/opus-package/lib
-        -DLIBFLAC_LIBRARY_DIR=${CMAKE_BINARY_DIR}/flac-package/lib
+        -DLIBSNDFILE_LIBRARY_DIR=${CMAKE_BINARY_DIR}/libsndfile-package/${CMAKE_INSTALL_LIBDIR}
+        -DLIBOGG_LIBRARY_DIR=${CMAKE_BINARY_DIR}/ogg-package/${CMAKE_INSTALL_LIBDIR}
+        -DLIBVORBIS_LIBRARY_DIR=${CMAKE_BINARY_DIR}/vorbis-package/${CMAKE_INSTALL_LIBDIR}
+        -DLIBOPUS_LIBRARY_DIR=${CMAKE_BINARY_DIR}/opus-package/${CMAKE_INSTALL_LIBDIR}
+        -DLIBFLAC_LIBRARY_DIR=${CMAKE_BINARY_DIR}/flac-package/${CMAKE_INSTALL_LIBDIR}
 
         -DPC_OGG_INCLUDE_DIRS=${CMAKE_BINARY_DIR}/ogg-package/include
         -DPC_VORBIS_INCLUDE_DIRS=${CMAKE_BINARY_DIR}/vorbis-package/include


### PR DESCRIPTION
The vendored dependencies use the [GNUInstallDirs](https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html) CMake module to determine where they put their built libraries. On most systems this will be "PREFIX/lib" but on some this will be "PREFIX/lib64", so assuming it will always be "PREFIX/lib" is not portable.

I had to manually link the API against librt for reasons I didn't really investigate. It shouldn't negatively impact the build on other distros to manually add it to the lib link list, but this should still be tested on Raspberry Pi OS and Ubuntu LTS to ensure that.

These changes need testing on other supported systems, but did allow Sonic Pi to build on NixOS for me with otherwise minimal modification. This should probably be cleaned up further, but I'm going ahead and opening the PR for feedback and testing.