### PR TITLE
Build - make ImGui-based interface optional

### DIFF
--- a/app/gui/CMakeLists.txt
+++ b/app/gui/CMakeLists.txt
@@ -1,2 +1,9 @@
+option(BUILD_IMGUI_INTERFACE "Build the ImGui-based graphical interface" ON)
+
+message(STATUS "ImGui Interface: ${BUILD_IMGUI_INTERFACE}")
+
 add_subdirectory(qt)
-add_subdirectory(imgui)
+
+if(BUILD_IMGUI_INTERFACE)
+  add_subdirectory(imgui)
+endif()


### PR DESCRIPTION
Right now the ImGui-based interface is always built without the ability to change that during the configure phase without modifying the "app/gui/CMakeLists.txt" file. This PR makes the interface optional and also set to not be built by default, since presumably most people will just want the Qt interface. I can change it to be built by default again if desired.

With this PR you can enable the ImGui interface via the following when running CMake during the configure phase:
```
cmake <cmake_args> -DBUILD_IMGUI_INTERFACE=ON <app_dir>
```


Do you have thoughts on making the ImGui interface optional and not built by default, @cmaughan and @samaaron?


As an additional question: would you want this option to be able to be set from the {mac,linux,pi}-config.sh scripts?

Right now they have minimal argument parsing code which would probably have to be rewritten (preumsably with getopt) to accodomate new flags. I am happy to do this but would want guidance on how it should work for someone using the scripts.