### PR TITLE
add note on qt@5 for mac build

### DIFF
--- a/BUILD-MAC.md
+++ b/BUILD-MAC.md
@@ -68,9 +68,11 @@ Once you have Homebrew installed, pulling in the rest of the
 dependencies is a couple of lines to execute within a terminal:
 
 ```
-brew install qt cmake
-
+brew install qt@5 cmake
 ```
+
+The default version Brew installs is Qt 6 which can prevent the application
+from linking correctly in the build.
 
 ## 2. Preparing the Build
 
@@ -141,8 +143,7 @@ directly either by double clicking it in the Finder or via the terminal
 (from within the `build` directory):
 
 ```
-./Sonic\ Pi.app/Contents/MacOS/Sonic\ Pi
-
+./gui/qt/Sonic\ Pi.app/Contents/MacOS/Sonic\ Pi
 ```
 
 ## Good Luck!


### PR DESCRIPTION
On macOS Big Sur I just ran through the build process on master branch, and hit a snag where brew now installs Qt 6 by default, which CMake complains about.  After installing Qt 5, CMake configure succeeds, build proceeds until final link step which appears to succeed but spits out a lot of warnings. Running the built app complains that 
```
$ ./gui/qt/Sonic\ Pi.app/Contents/MacOS/Sonic\ Pi 
qt.qpa.plugin: Could not find the Qt platform plugin "cocoa" in ""
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

Abort trap: 6
```
`brew uninstall qt` fixes this; the build finishes without warning and the app launches w/o hitch.

So I updated the macOS build readme in this PR to match what worked.