### PR TITLE
Updated license info for GPL synthdefs

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,7 @@
 # License
 
 ## Main Source
-(contents of [app/](https://github.com/sonic-pi-net/sonic-pi/tree/main/app) and [etc/synthdefs/](https://github.com/sonic-pi-net/sonic-pi/tree/main/etc/synthdefs) directories)
+(contents of [app/](https://github.com/sonic-pi-net/sonic-pi/tree/main/app) directory)
 
 The MIT License (MIT)
 
@@ -68,6 +68,16 @@ have been obtained from the
 [Adventure Kid](http://www.adventurekid.se/akrt/waveforms/adventure-kid-waveforms/)
 site.
 
+## Synthdefs
+(contents of [etc/synthdefs/](https://github.com/sonic-pi-net/sonic-pi/tree/main/etc/synthdefs) directory)
+
+The bundled synthdefs are licensed under the [MIT License](http://opensource.org/licenses/MIT) with the following exceptions, which are licensed under the [GNU General Public License v3](https://www.gnu.org/licenses/gpl-3.0.html):
+
+* [etc/synthdefs/designs/supercollider/bass_foundation.scd](https://github.com/sonic-pi-net/sonic-pi/tree/main/etc/synthdefs/designs/supercollider/bass_foundation.scd)
+* [etc/synthdefs/designs/supercollider/bass_highend.scd](https://github.com/sonic-pi-net/sonic-pi/tree/main/etc/synthdefs/designs/supercollider/bass_highend.scd)
+* [etc/synthdefs/designs/supercollider/winwood_lead.scd](https://github.com/sonic-pi-net/sonic-pi/tree/main/etc/synthdefs/designs/supercollider/winwood_lead.scd)
+
+See their source files for links to the original designs.
 
 ## Bundled Software
 The following is a list of the software included in Sonic Pi with their

--- a/app/server/ruby/lib/sonicpi/synths/synthinfo.rb
+++ b/app/server/ruby/lib/sonicpi/synths/synthinfo.rb
@@ -3308,7 +3308,7 @@ Steal This Sound,  Mitchell Sigman"
       end
 
       def doc
-        "A lead synth inspired by the Winwood songs from the early 80s.  Adapted for Sonic Pi from [Steal This Sound](https://raw.githubusercontent.com/supercollider/supercollider/develop/examples/demonstrations/stealthissound.scd). Published there under [GPL v3](https://www.gnu.org/licenses/gpl-3.0.en.html), so re-published under the same terms. The source code is available [on the Sonic Pi GitHub repository](https://github.com/sonic-pi-net/sonic-pi). Date of modification: 10.01.2021"
+        "A lead synth inspired by the Winwood songs from the early 80s. Adapted for Sonic Pi from [Steal This Sound](https://raw.githubusercontent.com/supercollider/supercollider/develop/examples/demonstrations/stealthissound.scd)."
       end
 
       def arg_defaults
@@ -3390,7 +3390,7 @@ Steal This Sound,  Mitchell Sigman"
       end
 
       def doc
-        "A soft bass synth inspired by the sounds of the 80s. Use together with :bass_highend if you want to give it a gargling component. Adapted for Sonic Pi from [Steal This Sound](https://raw.githubusercontent.com/supercollider/supercollider/develop/examples/demonstrations/stealthissound.scd). Published there under [GPL v3](https://www.gnu.org/licenses/gpl-3.0.en.html), so re-published under the same terms. The source code is available [on the Sonic Pi GitHub repository](https://github.com/sonic-pi-net/sonic-pi). Date of modification: 10.01.2021"
+        "A soft bass synth inspired by the sounds of the 80s. Use together with :bass_highend if you want to give it a gargling component. Adapted for Sonic Pi from [Steal This Sound](https://raw.githubusercontent.com/supercollider/supercollider/develop/examples/demonstrations/stealthissound.scd)."
       end
 
       def arg_defaults
@@ -3443,7 +3443,7 @@ Steal This Sound,  Mitchell Sigman"
       end
 
       def doc
-        "An addition to the :bass_foundation synth inspired by the sounds of the 80s. Use them together if you want to give it a rough, slurping, or gargling component. Adapted for Sonic Pi from [Steal This Sound](https://raw.githubusercontent.com/supercollider/supercollider/develop/examples/demonstrations/stealthissound.scd). Published there under [GPL v3](https://www.gnu.org/licenses/gpl-3.0.en.html), so re-published under the same terms. The source code is available [on the Sonic Pi GitHub repository](https://github.com/sonic-pi-net/sonic-pi). Date of modification: 11.01.2021"
+        "An addition to the :bass_foundation synth inspired by the sounds of the 80s. Use them together if you want to give it a rough, slurping, or gargling component. Adapted for Sonic Pi from [Steal This Sound](https://raw.githubusercontent.com/supercollider/supercollider/develop/examples/demonstrations/stealthissound.scd)."
       end
 
       def arg_defaults


### PR DESCRIPTION
It's been a long time ... here comes a complement to PR [Synths winwood_lead, bass_foundation, and bass_highend #2628](https://github.com/sonic-pi-net/sonic-pi/pull/2628), (hopefully) fixing the license issues.

- removed license stuff from docs in `app/server/ruby/lib/sonicpi/synths/synthinfo.rb`
- updated `LICENSE.md`, using MIT for most and GPL for some synthdefs