### PR TITLE
Core - new fn - invert_around

### DIFF
--- a/app/server/ruby/test/test_ring.rb
+++ b/app/server/ruby/test/test_ring.rb
@@ -206,5 +206,19 @@ module SonicPi
     def test_index_empty_ring
       assert_nil(ring()[0])
     end
+
+    def test_invert_around
+      assert_equal(ring().invert_around(60), ring())
+      assert_equal(ring(60).invert_around(60), ring(60))
+      assert_equal(ring(60).invert_around(61), ring(62))
+      assert_equal(ring(60).invert_around(0), ring(-60))
+      assert_equal(ring(60).invert_around(60.5), ring(61))
+      assert_equal(ring(:c).invert_around(60), ring(60))
+      assert_equal(ring(60).invert_around(:c), ring(60))
+      assert_equal(ring(:r).invert_around(60), ring(nil))
+      assert_equal(ring(60, 61, 62).invert_around(60), ring(60, 59, 58))
+      assert_equal(ring(60, 61, 62).invert_around(:cs), ring(62, 61, 60))
+      assert_equal(ring(59, :rest, :cs).invert_around(:c), ring(61, nil, 59))
+    end
   end
 end


### PR DESCRIPTION
Implement the `invert_around` fn from #2089.
I've added some extra handling so that it works correctly with note names and rests, not just midi note numbers.

I moved the SPVector parts to the end, so that `WesternTheory.note` is defined before it's needed, and removed the duplicate definition (otherwise I would have needed yet another copy of it).

Also, I decided to go with the name `invert_around` for now, as suggested by @xavriley, but happy to change that if people prefer `invert`, or something else.