### PR TITLE
Update potentially confusing sample_duration explanation

### DIFF
--- a/etc/doc/tutorial/03.4-Enveloped-Samples.md
+++ b/etc/doc/tutorial/03.4-Enveloped-Samples.md
@@ -47,16 +47,18 @@ up to more than the duration of the sample, the sustain is simply set to
 
 ## Fade Outs
 
-To explore this, let's consider our Amen break in more detail. If we ask
-Sonic Pi how long the sample is:
+To explore this, let's consider our Amen break in more detail. Let's say
+Sonic Pi's tempo is set to the default 60 BPM. If we ask Sonic Pi how
+long the sample is:
 
 ```
 print sample_duration :loop_amen
 ```
 
 It will print out `1.753310657596372` which is the length of the sample
-in seconds. Let's just round that to `1.75` for convenience here. Now,
-if we set the release to `0.75`, something surprising will happen:
+in beats - and at 60 BPM, that is the same as 1.753310657596372 seconds.
+Let's just round that to `1.75` for convenience here. Now, if we set the
+release to `0.75`, something surprising will happen:
 
 ```
 sample :loop_amen, release: 0.75


### PR DESCRIPTION
Given that recent changes have introduced live interactive code examples into the documentation, the code example in Tutorial 3.4 for printing out a sample_duration can be potentially confusing. If the user has their global tempo set to something other than the default 60 BPM and runs this interactive example, a different value is printed out in the log panel to the one revealed in the tutorial.

To fix this, the tutorial now explains the output of this specific example in the context of the default 60 BPM tempo.

Additionally, the explanation now talks about sample_duration's output being returned as BPM rather than seconds.