### PR TITLE
Group text edits for undo/redo unless preview is live

### DIFF
--- a/app/gui/widgets/sonicpiscintilla.cpp
+++ b/app/gui/widgets/sonicpiscintilla.cpp
@@ -2467,10 +2467,14 @@ bool SonicPiScintilla::event(QEvent* evt)
         // The backstop below would otherwise run the full completion pipeline a
         // second time off this edit's textChanged, before the caret settles.
         m_keyEditGuard = true;
-        SendScintilla(SCI_BEGINUNDOACTION);
-        // Drop the preview first so the keystroke edits the user's typed text (or,
-        // for a slider, leaves its committed value), then let the editor process it.
-        if (m_pvStart >= 0) clearPreview();
+        if (m_pvLive)
+        {
+            SendScintilla(SCI_BEGINUNDOACTION);
+            // Drop the preview first so the keystroke edits the user's typed text
+            // (or, for a slider, leaves its committed value), then let the editor
+            // process it.
+            if (m_pvStart >= 0) clearPreview();
+        }
 
         // Let the editor insert/delete the character, then refresh the popup. This
         // path runs after the edit fully settles (cursor advanced), so the context
@@ -2510,7 +2514,10 @@ bool SonicPiScintilla::event(QEvent* evt)
                 break;
             }
         }
-        SendScintilla(SCI_ENDUNDOACTION);
+        if (m_pvLive)
+        {
+            SendScintilla(SCI_ENDUNDOACTION);
+        }
         m_keyEditGuard = false;
         return res;
     }


### PR DESCRIPTION
Previously, every individual keypress was treated as a separate event for undo/redo. This meant that multiple presses of the delete or backspace keys were undone/redone one at a time, which is a very slow and laborious process.

Only signalling an undo action if a preview is live allows multiple normal text edits to be grouped into a single undo/redo.

@samaaron I'm still in the process of understanding the v5 code, so I'd appreciate your eyes and any comments on this fix. It does appear to do what I would expect, namely allow normal text edits to be grouped in a single undo/redo action, while leaving live preview values as individual undo actions. I have tested it by doing the following:
- Typed `play 60, pan: `, scrolling to change the pan value a few times, and hitting `Esc`. Undoing cycles back through the inserted preview values and back to `play 60, pan: `. Redo does the reverse.
- Typed `chord :C, `, scrolled to change the chord name a few times, and hitting `Esc`. Same undo/redo behaviour as above.
- Typed `play `, and immediately backspaced to remove it. Undo/redo restores/removes it in whole, rather than a letter at a time.
- Typed `# test` and immediately backspaced to remove it. Same undo/redo behaviour as above.
