### PR TITLE
Add headless HTTP server mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Sonic Pi is under active development, and welcomes new contributors:
   - [Mac](BUILD-MAC.md)
   - [Windows](BUILD-WINDOWS.md)
   - [Raspberry Pi](BUILD-RASPBERRY-PI.md)
+* [Server Mode — HTTP API (no auth)](SERVER_MODE.md)
 * [License](LICENSE.md)
 * [Testing](TESTING.md)
 * [Translation](TRANSLATION.md)

--- a/SERVER_MODE.md
+++ b/SERVER_MODE.md
@@ -1,0 +1,311 @@
+# Sonic Pi — Server Mode (HTTP API, no auth)
+
+Run Sonic Pi headless and drive it over HTTP — no GUI, no token auth, just `POST /run` with code.
+
+```
+curl -X POST http://localhost:8000/run -H 'Content-Type: application/json' \
+  -d '{"code":"play 70; sleep 0.5; play 72"}'
+```
+
+> **No authentication. Binds `127.0.0.1` by default.** Only use `--host 0.0.0.0` on a trusted network.
+
+## 1. Quick start
+
+### From source (this repo)
+
+```bash
+# default: http://127.0.0.1:8000
+./bin/sonic-pi-server.sh
+
+# custom port / LAN
+./bin/sonic-pi-server.sh --port 3000
+./bin/sonic-pi-server.sh --host 0.0.0.0 --port 8000
+
+# env vars also work
+SONIC_PI_SERVER_PORT=8000 SONIC_PI_SERVER_HOST=127.0.0.1 ./bin/sonic-pi-server.sh
+
+# help
+app/server/ruby/bin/sonic-pi-server.rb --help
+```
+
+Direct Ruby (no wrapper script):
+
+```bash
+ruby app/server/ruby/bin/sonic-pi-server.rb --host 127.0.0.1 --port 8000
+```
+
+### Packaged builds
+
+The release packaging must include the two server-mode files and a Ruby with `webrick`; this change adds the source-tree entry point only. Until a release is built with those requirements, use a source checkout.
+
+If startup reports `cannot load such file -- webrick`, install the matching `webrick` package/gem or use Sonic Pi's bundled Ruby. `json` is part of Ruby's standard library; the rest of the runtime is vendored under `app/server/ruby`.
+
+### Verify
+
+```bash
+curl http://localhost:8000/
+curl http://localhost:8000/health
+curl http://localhost:8000/logs?limit=20
+```
+
+## 2. API
+
+All responses are JSON. CORS is enabled (`Access-Control-Allow-Origin: *`).
+
+| Method | Path | Body | Description |
+|--------|------|------|-------------|
+| `GET` | `/`, `/health`, `/status` | — | Help, version, endpoint list, current token/host/port |
+| `GET` | `/version` | — | `{version, booted}` |
+| `GET` | `/logs?limit=100` | — | Last buffered Spider logs (max 500, default limit 100). Each entry `{ts, type, msg}` where `type` is `info`, `log`, `error`, `syntax_error`, `run`, or `stop` |
+| `POST` | `/run`, `/run-code`, `/eval` | JSON or `text/plain` | Run Sonic Pi code |
+| `POST` | `/stop`, `/stop-all`, `/stop-all-jobs` | JSON `{job_id}` optional | Stop all jobs or one job |
+
+### `POST /run`
+
+Preferred content type: `application/json`. `text/plain` is also accepted (raw code as body).
+
+JSON body:
+
+```json
+{
+  "code": "live_loop :a do\n  play scale(:c4, :major).tick\n  sleep 0.25\nend",
+  "workspace": "api"
+}
+```
+
+- `code` (required) — also accepted as `body` or `src`. Query param `?code=` works too for quick tests.
+- `workspace` (optional, default `"api"`) — workspace name tagged on the job (shows up in `/logs` and spider logs).
+
+Raw text alternative:
+
+```bash
+curl -X POST http://localhost:8000/run \
+  -H 'Content-Type: text/plain' \
+  --data-binary 'play 70; sleep 0.5; play 72'
+```
+
+Success (200):
+
+```json
+{"status":"ok","message":"code sent","workspace":"api"}
+```
+
+Error (400):
+
+```json
+{"status":"error","error":"missing \"code\" (JSON string). Example: {\"code\":\"play 70\"} or text/plain body"}
+```
+
+### `POST /stop`
+
+Stop all jobs, or one job by id:
+
+```bash
+# stop everything (like pressing Stop in the GUI)
+curl -X POST http://localhost:8000/stop
+
+# stop one job
+curl -X POST http://localhost:8000/stop \
+  -H 'Content-Type: application/json' \
+  -d '{"job_id": 42}'
+
+# also accepts jobId / id / ?job_id=42
+```
+
+Success:
+
+```json
+{"status":"ok","message":"stopped all jobs"}
+{"status":"ok","message":"stopped job 42"}
+```
+
+### `GET /logs`
+
+```bash
+curl http://localhost:8000/logs?limit=50 | jq .
+```
+
+```json
+{
+  "logs": [
+    {"ts":"12:34:56.789","type":"info","msg":"Server ready — token 12345"},
+    {"ts":"12:34:57.012","type":"run","msg":"POST /run workspace=api code=live_loop :a do"},
+    {"ts":"12:34:57.100","type":"log","msg":"run 1: synth :beep, {note: 70}"},
+    {"ts":"12:34:57.200","type":"error","msg":"run 1 line 2: undefined method `plaay' | plaay 70"}
+  ],
+  "count": 4
+}
+```
+
+Logs are also streamed to stdout (useful for `journalctl` / Docker).
+
+## 3. Examples
+
+### cURL
+
+```bash
+# health
+curl http://localhost:8000/
+
+# one-shot note
+curl -X POST http://localhost:8000/run \
+  -H 'Content-Type: application/json' \
+  -d '{"code":"play 70"}'
+
+# live loop (runs until stopped)
+curl -X POST http://localhost:8000/run \
+  -H 'Content-Type: application/json' \
+  -d '{"code":"live_loop :drums do\n  sample :bd_haus\n  sleep 0.5\nend"}'
+
+# with workspace tag
+curl -X POST http://localhost:8000/run \
+  -H 'Content-Type: application/json' \
+  -d '{"code":"play chord(:c4, :major)","workspace":"my-buffer"}'
+
+# stop
+curl -X POST http://localhost:8000/stop
+
+# check what happened
+curl http://localhost:8000/logs?limit=20
+```
+
+### Python
+
+```python
+import requests
+
+BASE = "http://localhost:8000"
+
+requests.post(f"{BASE}/run", json={"code": "play 70"})
+requests.post(f"{BASE}/run", json={"code": "live_loop :a do\n  play scale(:c4,:major).tick\n  sleep 0.25\nend"})
+print(requests.get(f"{BASE}/logs", params={"limit": 5}).json())
+
+# stop all
+requests.post(f"{BASE}/stop")
+```
+
+### JavaScript / Node
+
+```js
+await fetch("http://localhost:8000/run", {
+  method: "POST",
+  headers: {"Content-Type": "application/json"},
+  body: JSON.stringify({code: "play 70"})
+});
+await fetch("http://localhost:8000/logs").then(r => r.json()).then(console.log);
+await fetch("http://localhost:8000/stop", {method: "POST"});
+```
+
+### Browser (CORS enabled)
+
+```js
+// from any http://localhost:* page — no proxy needed
+fetch("http://localhost:8000/run", {
+  method: "POST",
+  headers: {"Content-Type": "application/json"},
+  body: JSON.stringify({code: 'sample :bd_haus; sleep 0.5'})
+});
+```
+
+## 4. How it works
+
+```
+HTTP (WEBrick :8000) → /run → OSC UDP /run-code → Spider (Ruby runtime)
+                                      ↕
+                                   Daemon (port discovery, keep-alive, SuperSonic boot)
+                                      ↕
+                                   SuperSonic (audio engine, scope/metrics shm)
+```
+
+- Uses `app/server/ruby/bin/headless_boot.rb:HeadlessBoot` — the same harness as `headless-run.rb` / `headless-record.rb`.
+- `HeadlessBoot#boot!` spawns `app/server/ruby/bin/daemon.rb`, parses its `daemon gui_listen gui_send scsynth osc_cues token` line, keeps the daemon alive with `/daemon/keep-alive`, and waits for Spider + SuperSonic (`/ack` + `/supersonic/info` / `Live Coding begin`).
+- `HeadlessBoot` forwards Spider messages to registered listeners after its normal handlers run, so the HTTP log buffer does not interfere with the boot Promises or console output. `/logs` is a 500-entry ring buffer.
+- Code is sent as a single `/run-code` OSC message with `workspace` — same as the GUI's `Run` button.
+
+## 5. Configuration
+
+| Flag / Env | Default | Description |
+|------------|---------|-------------|
+| `--host HOST` / `SONIC_PI_SERVER_HOST` | `127.0.0.1` | Bind address. Use `0.0.0.0` to expose on LAN (no auth!) |
+| `--port PORT` / `SONIC_PI_SERVER_PORT` | `8000` | HTTP port |
+| `-h, --help` | — | Help |
+| `SONIC_PI_HOME` | `~/.sonic-pi` | Where logs/config live (like GUI). See `PACKAGING.md` |
+| `SONIC_PI_ROOT` / `SONIC_PI_ETC_PATH` | auto | Installed tree root (packagers) |
+
+## 6. Deployment
+
+### systemd (Linux / Raspberry Pi)
+
+```ini
+# /etc/systemd/system/sonic-pi-server.service
+[Unit]
+Description=Sonic Pi Server Mode
+After=sound.target network.target
+
+[Service]
+Type=simple
+User=pi
+WorkingDirectory=/opt/sonic-pi
+ExecStart=/opt/sonic-pi/bin/sonic-pi-server.sh --host 127.0.0.1 --port 8000
+Restart=on-failure
+Environment=SONIC_PI_HOME=/home/pi
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now sonic-pi-server
+journalctl -u sonic-pi-server -f
+curl http://localhost:8000/
+```
+
+### Docker
+
+```dockerfile
+FROM ruby:3.2-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential pkg-config libasound2-dev jackd2 supercollider-server \
+    && rm -rf /var/lib/apt/lists/*
+COPY . /sonic-pi
+WORKDIR /sonic-pi
+EXPOSE 8000
+CMD ["./bin/sonic-pi-server.sh", "--host", "0.0.0.0", "--port", "8000"]
+```
+
+> Audio in containers needs `--device /dev/snd` and often `--group-add audio` or host PulseAudio/PipeWire forwarding — out of scope here.
+
+## 7. Security
+
+- **No auth.** Anyone who can reach the HTTP port can run arbitrary Sonic Pi code (which can `require`, shell out via Ruby, etc.).
+- Default bind is `127.0.0.1` (loopback only). Don't expose to the internet without a reverse proxy that adds auth (e.g. `nginx` + basic auth, Tailscale, WireGuard).
+- If you must bind `0.0.0.0`, firewall it: `ufw allow from 192.168.1.0/24 to any port 8000`.
+
+## 8. Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| `Address already in use - bind(2) for 127.0.0.1:8000` | Another server/GUI on that port. Use `--port 8001` or `lsof -i :8000` |
+| Boot hangs at `waiting for server...` | Check `~/.sonic-pi/log/daemon.log` and `spider.log`. Often JACK/PipeWire or missing SuperSonic binary (`app/server/native/sonic-pi-supersonic`) |
+| No sound | Server mode leaves mixer at full (unlike `headless-run.rb` which mutes). Check system volume, JACK/PipeWire, and `~/.sonic-pi/log/supersonic.log` |
+| `webrick` not found | Ruby < 3 bundled webrick; Ruby 3+ needs `gem install webrick`. Or use the bundled `app/server/native/ruby` |
+| CORS error in browser | Server sends `Access-Control-Allow-Origin: *` — ensure you're POSTing to the exact host/port the server printed |
+
+## 9. Files
+
+| Path | Role |
+|------|------|
+| `app/server/ruby/bin/sonic-pi-server.rb` | HTTP server (this feature) |
+| `bin/sonic-pi-server.sh` | Wrapper — picks `app/server/native/ruby` if present else `ruby` |
+| `app/server/ruby/bin/headless_boot.rb` | Shared boot harness |
+| `app/server/ruby/bin/daemon.rb` | Port discovery, SuperSonic + Spider spawn, keep-alive |
+| `app/server/ruby/bin/repl.rb` | Interactive REPL (also headless, but stdin-based) |
+| `app/server/ruby/bin/headless-run.rb` | One-shot runner (muted) |
+| `app/server/ruby/bin/headless-record.rb` | Realtime WAV recorder |
+
+## 10. See also
+
+- [README](README.md) — project overview
+- [BUILD-LINUX](BUILD-LINUX.md), [BUILD-MAC](BUILD-MAC.md), [BUILD-WINDOWS](BUILD-WINDOWS.md), [BUILD-RASPBERRY-PI](BUILD-RASPBERRY-PI.md) — building
+- [PACKAGING](PACKAGING.md) — `SONIC_PI_ROOT` / `SONIC_PI_HOME` knobs

--- a/app/server/ruby/bin/headless_boot.rb
+++ b/app/server/ruby/bin/headless_boot.rb
@@ -21,6 +21,14 @@ module SonicPi
       @server_started = Promise.new
       @engine_started = Promise.new
       @errors = []
+      @log_listeners = []
+    end
+
+    # Register a listener for messages emitted by Spider. This lets headless
+    # front-ends consume logs without replacing the OSC handlers that manage
+    # the boot handshake and console output.
+    def add_log_listener(&listener)
+      @log_listeners << listener if listener
     end
 
     def boot!
@@ -90,6 +98,7 @@ module SonicPi
 
       osc.add_method("/log/info") do |m|
         say "LOG  #{m[1]}"
+        notify_log_listeners(:info, m)
         # The engine no longer pushes /supersonic/info unprompted (it now
         # replies to the GUI's /supersonic/setup), so treat the spider's
         # final boot message as engine-ready too.
@@ -104,19 +113,30 @@ module SonicPi
         texts = []
         msgs.each_slice(2) { |_c, t| texts << t if t }
         label = (thread.to_s.empty? || thread == "\"\"") ? "run" : thread
-        texts.each { |t| say "#{label}: #{t}" }
+        texts.each do |t|
+          say "#{label}: #{t}"
+          notify_log_listeners(:log, [label, t])
+        end
       end
 
       osc.add_method("/error") do |m|
         @errors << "run #{m[0]} line #{m[3]}: #{m[1]}"
         say "ERROR run #{m[0]} line #{m[3]}: #{m[1]}"
         say "  #{m[2]}"
+        notify_log_listeners(:error, m)
       end
 
       osc.add_method("/syntax_error") do |m|
         @errors << "syntax run #{m[0]} line #{m[3]}: #{m[1]}"
         say "SYNTAX ERROR run #{m[0]} line #{m[3]}: #{m[1]} | #{m[2]}"
+        notify_log_listeners(:syntax_error, m)
       end
+    end
+
+    def notify_log_listeners(type, message)
+      @log_listeners.each { |listener| listener.call(type, message) }
+    rescue StandardError => e
+      warn "HeadlessBoot log listener failed: #{e.message}"
     end
   end
 end

--- a/app/server/ruby/bin/sonic-pi-server.rb
+++ b/app/server/ruby/bin/sonic-pi-server.rb
@@ -1,0 +1,298 @@
+#!/usr/bin/env ruby
+#--
+# Sonic Pi — Simple HTTP Server Mode (no auth)
+#
+# Boots the Sonic Pi daemon + Spider + SuperSonic without the Qt GUI
+# and exposes a tiny HTTP API so you can code it remotely:
+#
+#   POST /run   { "code": "play 70; sleep 0.5; play 72" }
+#   POST /stop  { }  or  { "job_id": 123 }
+#   GET  /health, GET /, GET /logs
+#
+# Usage:
+#   ruby app/server/ruby/bin/sonic-pi-server.rb [--host 127.0.0.1] [--port 8000]
+#   ./bin/sonic-pi-server.sh --port 8000 --host 0.0.0.0
+#
+# No authentication — bind to 127.0.0.1 by default. Use --host 0.0.0.0
+# only on a trusted network.
+#
+# Dependencies: json from Ruby's standard library, webrick, and vendored
+# Sonic Pi libs. Some system Ruby installations package webrick separately.
+#++
+
+require 'webrick'
+require 'json'
+require 'thread'
+require 'uri'
+
+require_relative "../paths"
+require_relative "headless_boot"
+
+module SonicPi
+  class ServerMode
+    VERSION = "5.0.0-server"
+
+    def initialize(host: "127.0.0.1", port: 8000)
+      @host = host
+      @port = port
+      @boot = HeadlessBoot.new
+      @logs = [] # {ts, type, msg}
+      @logs_mu = Mutex.new
+      @max_logs = 500
+    end
+
+    def push_log(type, msg)
+      entry = {ts: Time.now.strftime("%H:%M:%S.%3N"), type: type, msg: msg}
+      @logs_mu.synchronize do
+        @logs << entry
+        @logs.shift while @logs.size > @max_logs
+      end
+      # also print to stdout for journald/docker logs
+      puts "[#{entry[:ts]}] [#{type}] #{msg}"
+      $stdout.flush
+    end
+
+    def boot!
+      puts "Sonic Pi Server Mode — booting daemon + engine..."
+      puts "Host: #{@host}  Port: #{@port}"
+      @boot.add_log_listener do |type, message|
+        case type
+        when :info
+          push_log("info", message[1].to_s)
+        when :log
+          push_log("log", "#{message[0]}: #{message[1]}")
+        when :error, :syntax_error
+          push_log(type.to_s, "run #{message[0]} line #{message[3]}: #{message[1]} | #{message[2]}")
+        end
+      end
+      @boot.boot!
+      puts "Sonic Pi Server Mode — boot done (token #{@boot.token})"
+      push_log("info", "Server ready — token #{@boot.token}")
+    end
+
+    def start_http!
+      server = WEBrick::HTTPServer.new(
+        Port: @port,
+        BindAddress: @host,
+        AccessLog: [],
+        Logger: WEBrick::Log.new($stderr, WEBrick::Log::INFO)
+      )
+
+      # Graceful shutdown
+      %w[INT TERM].each { |sig| trap(sig) { server.shutdown } }
+
+      cors = lambda do |res|
+        res['Access-Control-Allow-Origin'] = '*'
+        res['Access-Control-Allow-Methods'] = 'GET, POST, OPTIONS'
+        res['Access-Control-Allow-Headers'] = 'Content-Type'
+      end
+
+      json_res = lambda do |res, obj, status: 200|
+        cors.call(res)
+        res.status = status
+        res['Content-Type'] = 'application/json'
+        res.body = JSON.generate(obj)
+      end
+
+      help_payload = lambda do
+        {
+          name: "Sonic Pi Server",
+          version: VERSION,
+          status: "ok",
+          booted: true,
+          token: @boot.token,
+          endpoints: {
+            "GET /" => "this help",
+            "GET /health" => "health check",
+            "GET /logs?limit=100" => "recent spider logs",
+            "POST /run" => '{ "code": "play 70" }',
+            "POST /stop" => '{ } or { "job_id": 123 } — stop all or one job'
+          },
+          example: 'curl -X POST http://localhost:8000/run -H "Content-Type: application/json" -d \'{"code":"live_loop :a do; play scale(:c4,:major).tick; sleep 0.25; end"}\'',
+          host: @host,
+          port: @port
+        }
+      end
+
+      server.mount_proc '/' do |req, res|
+        # CORS preflight for any path
+        if req.request_method == 'OPTIONS'
+          cors.call(res)
+          res.status = 204
+          res.body = ''
+          next
+        end
+
+        path = req.path
+        method = req.request_method
+        query = URI.decode_www_form(req.query_string.to_s).to_h
+
+        if method == 'GET' && ['/', '/health', '/status'].include?(path)
+          json_res.call(res, help_payload.call)
+          next
+        end
+
+        if method == 'GET' && path == '/logs'
+          limit = (query['limit'] || '100').to_i.clamp(1, @max_logs)
+          logs = @logs_mu.synchronize { @logs.last(limit).dup }
+          json_res.call(res, {logs: logs, count: @logs_mu.synchronize { @logs.size }})
+          next
+        end
+
+        if method == 'GET' && path == '/version'
+          json_res.call(res, {version: VERSION, booted: true})
+          next
+        end
+
+        if ['/run', '/run-code', '/eval'].include?(path)
+          unless method == 'POST'
+            json_res.call(res, {status: "error", error: "method not allowed — use POST"}, status: 405)
+            next
+          end
+          body = req.body || ""
+          ctype = req['Content-Type'].to_s
+          data = {}
+          code = nil
+          workspace = nil
+          if ctype.include?('text/plain')
+            code = body
+          else
+            begin
+              data = body.strip.empty? ? {} : JSON.parse(body)
+            rescue JSON::ParserError => e
+              json_res.call(res, {status: "error", error: "invalid JSON: #{e.message}"}, status: 400)
+              next
+            end
+            code = data["code"] || data["body"] || data["src"]
+            workspace = data["workspace"] || "api"
+          end
+          code = query['code'] if query['code'] && (code.nil? || code.empty?)
+          workspace ||= "api"
+          unless code.is_a?(String) && !code.strip.empty?
+            json_res.call(res, {status: "error", error: 'missing "code" (JSON string). Example: {"code":"play 70"} or text/plain body'}, status: 400)
+            next
+          end
+          begin
+            # Single OSC send with workspace — HeadlessBoot#run sends without
+            # workspace, so bypass it and send explicitly.
+            @boot.eval_client.send("/run-code", @boot.token, code, workspace.to_s)
+            push_log("run", "POST #{path} workspace=#{workspace} code=#{code.lines.first&.strip&.slice(0,120)}")
+            json_res.call(res, {status: "ok", message: "code sent", workspace: workspace})
+          rescue => e
+            json_res.call(res, {status: "error", error: e.message}, status: 500)
+          end
+          next
+        end
+
+        if ['/stop', '/stop-all', '/stop-all-jobs'].include?(path)
+          unless method == 'POST'
+            json_res.call(res, {status: "error", error: "method not allowed — use POST"}, status: 405)
+            next
+          end
+          begin
+            body = req.body || ""
+            data = body.strip.empty? ? {} : (JSON.parse(body) rescue {})
+            job_id = data["job_id"] || data["jobId"] || data["id"] || query['job_id']
+            if job_id
+              unless job_id.to_s.match?(/\A[1-9]\d*\z/)
+                json_res.call(res, {status: "error", error: '"job_id" must be a positive integer'}, status: 400)
+                next
+              end
+              @boot.eval_client.send("/stop-job", @boot.token, job_id.to_i)
+              push_log("stop", "POST /stop job_id=#{job_id}")
+              json_res.call(res, {status: "ok", message: "stopped job #{job_id}"})
+            else
+              @boot.stop_all
+              push_log("stop", "POST /stop — stop-all-jobs")
+              json_res.call(res, {status: "ok", message: "stopped all jobs"})
+            end
+          rescue => e
+            json_res.call(res, {status: "error", error: e.message}, status: 500)
+          end
+          next
+        end
+
+        json_res.call(res, {status: "error", error: "not found: #{path}", hint: "GET / for help"}, status: 404)
+      end
+
+      puts ""
+      puts "=============================================="
+      puts " Sonic Pi Server listening on http://#{@host}:#{@port}"
+      puts "   GET  /        — help"
+      puts "   POST /run     — {\"code\":\"play 70\"}"
+      puts "   POST /stop    — stop all (or {\"job_id\":123})"
+      puts "   GET  /logs    — recent logs"
+      puts " No auth — bound to #{@host} (use --host 0.0.0.0 to expose on LAN)"
+      puts "=============================================="
+      puts ""
+      puts "Examples:"
+      puts "  curl http://#{@host}:#{@port}/"
+      puts "  curl -X POST http://#{@host}:#{@port}/run -H 'Content-Type: application/json' -d '{\"code\":\"play 70\"}'"
+      puts "  curl -X POST http://#{@host}:#{@port}/run -H 'Content-Type: application/json' -d '{\"code\":\"live_loop :d do\\n sample :bd_haus\\n sleep 0.5\\nend\"}'"
+      puts "  curl -X POST http://#{@host}:#{@port}/stop"
+      puts ""
+
+      server.start
+    end
+
+    def run
+      boot!
+      start_http!
+    end
+  end
+end
+
+if __FILE__ == $0
+  host = ENV["SONIC_PI_SERVER_HOST"] || "127.0.0.1"
+  port = ENV["SONIC_PI_SERVER_PORT"] || "8000"
+
+  args = ARGV.dup
+  until args.empty?
+    case (a = args.shift)
+    when "-h", "--help"
+      puts <<~HELP
+        Sonic Pi Server Mode (no auth)
+
+        Usage: ruby #{__FILE__} [options]
+
+        Options:
+          --host HOST   Bind address (default: #{host}, env SONIC_PI_SERVER_HOST)
+                        Use 0.0.0.0 to expose on your LAN (no auth!)
+          --port PORT   Port (default: #{port}, env SONIC_PI_SERVER_PORT)
+          -h, --help    This help
+
+        Endpoints (all JSON, CORS enabled):
+          GET  /, /health        Health + usage
+          GET  /logs?limit=100   Recent spider logs / errors
+          POST /run              Body: {"code":"play 70"} — run Sonic Pi code
+          POST /stop             Body: {} or {"job_id":123} — stop jobs
+
+        Examples:
+          curl http://localhost:8000/
+          curl -X POST http://localhost:8000/run -H 'Content-Type: application/json' \\
+            -d '{"code":"live_loop :a do; play scale(:c4,:major).tick; sleep 0.25; end"}'
+          curl -X POST http://localhost:8000/stop
+
+        From source:
+          ./bin/sonic-pi-server.sh --port 8000
+          ./bin/sonic-pi-server.sh --host 0.0.0.0 --port 8000
+
+      HELP
+      exit 0
+    when "--host"
+      host = args.shift or abort "--host needs a value"
+    when "--port", "-p"
+      port = args.shift or abort "--port needs a value"
+    when /\A--port=(.+)\z/
+      port = $1
+    when /\A--host=(.+)\z/
+      host = $1
+    else
+      abort "Unknown argument: #{a} (try --help)"
+    end
+  end
+
+  abort "--port must be an integer between 1 and 65535" unless port.to_s.match?(/\A\d+\z/) && (1..65_535).cover?(port.to_i)
+
+  SonicPi::ServerMode.new(host: host, port: port.to_i).run
+end

--- a/bin/sonic-pi-server.sh
+++ b/bin/sonic-pi-server.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Sonic Pi Server Mode — no auth, POST /run to code over HTTP
+# Usage: ./bin/sonic-pi-server.sh [--host 127.0.0.1] [--port 8000]
+set -e
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT_DIR="$( cd "${SCRIPT_DIR}/.." && pwd )"
+RUBY_PATH="${ROOT_DIR}/app/server/native/ruby/bin/ruby"
+if [ ! -x "${RUBY_PATH}" ]; then
+  RUBY_PATH="${ROOT_DIR}/ruby/bin/ruby"
+fi
+if [ ! -x "${RUBY_PATH}" ]; then
+  RUBY_PATH="ruby"
+fi
+exec "${RUBY_PATH}" "${ROOT_DIR}/app/server/ruby/bin/sonic-pi-server.rb" "$@"


### PR DESCRIPTION
Adds a headless HTTP server entry point for running and stopping Sonic Pi code, with basic health and log endpoints. Includes launcher and usage documentation.